### PR TITLE
Replace hex colors with Tailwind tokens

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -114,7 +114,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  border: 2px solid #ffd700;
+  border: 2px solid var(--dashYellow);
   border-radius: 0.75rem;
   pointer-events: none;
 }

--- a/components/market-cap-chart.tsx
+++ b/components/market-cap-chart.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef } from "react"
 import { DashcoinCard, DashcoinCardHeader, DashcoinCardTitle, DashcoinCardContent } from "@/components/ui/dashcoin-card"
 import type { MarketCapTimeData } from "@/types/dune"
-import { formatCurrency } from "@/lib/utils"
+import { formatCurrency, getCssVariable, hexToRgba } from "@/lib/utils"
 import { DuneQueryLink } from "@/components/dune-query-link"
 
 declare global {
@@ -34,14 +34,18 @@ export function MarketCapChart({ data }: MarketCapChartProps) {
       return dateA - dateB
     })
 
+    const dashYellow = getCssVariable("--dashYellow") || "#ffd700"
+    const dashYellowLight = getCssVariable("--dashYellow-light") || "#fff0a0"
+    const dashGreen = getCssVariable("--dashGreen-accent") || "#66cc33"
+
     const chartData = {
       labels: sortedData.map((item) => (item.date ? new Date(item.date).toLocaleDateString() : "Unknown")),
       datasets: [
         {
           label: "Market Cap (USD)",
           data: sortedData.map((item) => item.marketcap || 0),
-          borderColor: "#ffd700",
-          backgroundColor: "rgba(255, 215, 0, 0.1)",
+          borderColor: dashYellow,
+          backgroundColor: hexToRgba(dashYellow, 0.1),
           borderWidth: 2,
           fill: true,
           tension: 0.4,
@@ -49,8 +53,8 @@ export function MarketCapChart({ data }: MarketCapChartProps) {
         {
           label: "Holders",
           data: sortedData.map((item) => item.num_holders || 0),
-          borderColor: "#66cc33",
-          backgroundColor: "rgba(102, 204, 51, 0.1)",
+          borderColor: dashGreen,
+          backgroundColor: hexToRgba(dashGreen, 0.1),
           borderWidth: 2,
           fill: true,
           tension: 0.4,
@@ -71,7 +75,7 @@ export function MarketCapChart({ data }: MarketCapChartProps) {
               color: "rgba(42, 47, 14, 0.3)",
             },
             ticks: {
-              color: "#fff0a0",
+              color: dashYellowLight,
             },
           },
           y: {
@@ -79,7 +83,7 @@ export function MarketCapChart({ data }: MarketCapChartProps) {
               color: "rgba(42, 47, 14, 0.3)",
             },
             ticks: {
-              color: "#fff0a0",
+              color: dashYellowLight,
               callback: (value: number) => formatCurrency(value),
             },
           },
@@ -89,14 +93,14 @@ export function MarketCapChart({ data }: MarketCapChartProps) {
               display: false,
             },
             ticks: {
-              color: "#66cc33",
+              color: dashGreen,
             },
           },
         },
         plugins: {
           legend: {
             labels: {
-              color: "#fff0a0",
+              color: dashYellowLight,
             },
           },
           tooltip: {

--- a/components/market-cap-pie.tsx
+++ b/components/market-cap-pie.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef } from "react"
 import { DashcoinCard, DashcoinCardHeader, DashcoinCardTitle, DashcoinCardContent } from "@/components/ui/dashcoin-card"
 import type { TokenMarketCapData } from "@/types/dune"
-import { formatCurrency } from "@/lib/utils"
+import { formatCurrency, getCssVariable, hexToRgba } from "@/lib/utils"
 import { DuneQueryLink } from "@/components/dune-query-link"
 
 interface MarketCapPieProps {
@@ -54,14 +54,18 @@ export function MarketCapPie({ data }: MarketCapPieProps) {
 
     if (topTokens.length === 0) return
 
+    const dashYellow = getCssVariable("--dashYellow") || "#ffd700"
+    const dashGreen = getCssVariable("--dashGreen-accent") || "#66cc33"
+    const dashYellowLight = getCssVariable("--dashYellow-light") || "#fff0a0"
+
     const colors = [
-      "#ffd700", 
-      "#66cc33", 
-      "#ff6666", 
-      "#0077cc", 
-      "#99dd66", 
-      "#e6b800", 
-      "#339900", 
+      dashYellow,
+      dashGreen,
+      "#ff6666",
+      "#0077cc",
+      "#99dd66",
+      "#e6b800",
+      "#339900",
       "#ff9999", 
       "#00aaff", 
       "#cccccc", 
@@ -89,7 +93,7 @@ export function MarketCapPie({ data }: MarketCapPieProps) {
           legend: {
             position: "right",
             labels: {
-              color: "#fff0a0",
+              color: dashYellowLight,
               font: {
                 size: 12,
               },

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -83,3 +83,19 @@ export function getTimeAgo(dateString: string): string {
   const yearsAgo = Math.floor(monthsAgo / 12)
   return `${yearsAgo} year${yearsAgo === 1 ? '' : 's'} ago`
 }
+
+export function getCssVariable(name: string): string {
+  if (typeof window === 'undefined') return ''
+  return getComputedStyle(document.documentElement)
+    .getPropertyValue(name)
+    .trim()
+}
+
+export function hexToRgba(hex: string, alpha: number): string {
+  const sanitized = hex.replace('#', '')
+  const bigint = parseInt(sanitized, 16)
+  const r = (bigint >> 16) & 255
+  const g = (bigint >> 8) & 255
+  const b = bigint & 255
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`
+}


### PR DESCRIPTION
## Summary
- add CSS variable helpers in utils
- use palette tokens for market cap charts
- apply dashYellow border for card style

## Testing
- `npm run lint` *(fails: next not found)*