### PR TITLE
Use GOOGLE_API_KEY from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The cache admin interface is available at `/admin/cache`. This interface allows 
 - `KV_REST_API_TOKEN`: Your Upstash Redis API token
 - `ENABLE_DUNE_API`: Set to `true` to enable real Dune API calls (default: `false`)
 - `VERCEL_ENV`: Automatically set by Vercel to indicate the environment
+- `GOOGLE_API_KEY`: API key for accessing Google Sheets data
 
 ## Cache Keys
 

--- a/app/actions/googlesheet-action.ts
+++ b/app/actions/googlesheet-action.ts
@@ -5,7 +5,7 @@ interface ResearchScoreData {
 }
 
 export async function fetchTokenResearch(): Promise<ResearchScoreData[]> {
-  const API_KEY = 'AIzaSyC8QxJez_UTHUJS7vFj1J3Sje0CWS9tXyk';
+  const API_KEY = process.env.GOOGLE_API_KEY;
   const SHEET_ID = '1Nra5QH-JFAsDaTYSyu-KocjbkZ0MATzJ4R-rUt-gLe0';
   const SHEET_NAME = 'Dashcoin Scoring';
   const RANGE = `${SHEET_NAME}!A1:K30`;

--- a/app/tokendetail/[symbol]/page.tsx
+++ b/app/tokendetail/[symbol]/page.tsx
@@ -34,7 +34,7 @@ interface TokenResearchData {
 }
 
 async function fetchTokenResearch(tokenSymbol: string): Promise<TokenResearchData | null> {
-  const API_KEY = 'AIzaSyC8QxJez_UTHUJS7vFj1J3Sje0CWS9tXyk';
+  const API_KEY = process.env.GOOGLE_API_KEY;
   const SHEET_ID = '1Nra5QH-JFAsDaTYSyu-KocjbkZ0MATzJ4R-rUt-gLe0';
   const SHEET_NAME = 'Dashcoin Scoring';
   const RANGE = `${SHEET_NAME}!A1:M30`;

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,6 +9,9 @@ const nextConfig = {
   images: {
     unoptimized: true,
   },
+  env: {
+    GOOGLE_API_KEY: process.env.GOOGLE_API_KEY,
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- read Google API key from environment for token detail and google sheet actions
- expose `GOOGLE_API_KEY` via Next.js config
- document the new variable in README

## Testing
- `npm run lint` *(fails: `next` not found)*