### PR TITLE
Consolidate color variables

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -4,37 +4,37 @@
 
 @layer base {
   :root {
-    --background: 70 60% 22%; /* dashGreen */
-    --foreground: 48 100% 95%; /* dashYellow light */
+    --background: 0 0% 100%;
+    --foreground: 0 0% 3.9%;
 
-    --card: 70 60% 12%; /* dashGreen-card - much darker */
-    --card-foreground: 48 100% 95%;
+    --card: 0 0% 100%;
+    --card-foreground: 0 0% 3.9%;
 
-    --popover: 70 60% 12%; /* dashGreen-card - much darker */
-    --popover-foreground: 48 100% 95%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 0 0% 3.9%;
 
-    --primary: 48 100% 50%; /* dashYellow */
-    --primary-foreground: 70 60% 10%;
+    --primary: 0 0% 9%;
+    --primary-foreground: 0 0% 98%;
 
-    --secondary: 70 60% 30%; /* dashGreen light */
-    --secondary-foreground: 0 0% 100%;
+    --secondary: 0 0% 96.1%;
+    --secondary-foreground: 0 0% 9%;
 
-    --muted: 70 30% 30%;
-    --muted-foreground: 48 30% 90%;
+    --muted: 0 0% 96.1%;
+    --muted-foreground: 0 0% 45.1%;
 
-    --accent: 0 100% 70%; /* dashRed */
-    --accent-foreground: 0 0% 100%;
+    --accent: 0 0% 96.1%;
+    --accent-foreground: 0 0% 9%;
 
-    --destructive: 0 100% 50%;
-    --destructive-foreground: 0 0% 100%;
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 0 0% 98%;
 
-    --border: 70 30% 30%;
-    --input: 70 30% 30%;
-    --ring: 48 100% 50%;
+    --border: 0 0% 89.8%;
+    --input: 0 0% 89.8%;
+    --ring: 0 0% 3.9%;
 
-    --radius: 0.75rem;
+    --radius: 0.5rem;
 
-      --font-inter: 'Inter', sans-serif;
+    --font-inter: 'Inter', sans-serif;
     --font-bangers: 'Bangers', cursive;
     --dashcoin-yellow: #F6BE00;
     --dashcoin-yellow-dark: #E9B200;
@@ -44,48 +44,49 @@
     --dashcoin-green-light: #1A2C24;
     --dashcoin-green-accent: #21BB89;
     --dashcoin-black: #121212;
-  --dashcoin-red: #F05252;
-  }
+    --dashcoin-red: #F05252;
 
-  @layer base {
-  body {
-    @apply bg-dashGreen text-slate-50;
+    --dashGreen: var(--dashcoin-green);
+    --dashGreen-dark: var(--dashcoin-green-dark);
+    --dashGreen-light: var(--dashcoin-green-light);
+    --dashGreen-accent: var(--dashcoin-green-accent);
+    --dashYellow: var(--dashcoin-yellow);
+    --dashYellow-dark: var(--dashcoin-yellow-dark);
+    --dashYellow-light: var(--dashcoin-yellow-light);
+    --dashBlack: var(--dashcoin-black);
+    --dashRed: var(--dashcoin-red);
   }
-}
-
 
   .dark {
-    --background: 70 60% 12%; /* darker dashGreen */
-    --foreground: 48 100% 95%; /* dashYellow light */
+    --background: 0 0% 3.9%;
+    --foreground: 0 0% 98%;
 
-    --card: 70 60% 7%; /* dashGreen-cardDark - very dark */
-    --card-foreground: 48 100% 95%;
+    --card: 0 0% 3.9%;
+    --card-foreground: 0 0% 98%;
 
-    --popover: 70 60% 7%; /* dashGreen-cardDark - very dark */
-    --popover-foreground: 48 100% 95%;
+    --popover: 0 0% 3.9%;
+    --popover-foreground: 0 0% 98%;
 
-    --primary: 48 100% 50%; /* dashYellow */
-    --primary-foreground: 70 60% 10%;
+    --primary: 0 0% 98%;
+    --primary-foreground: 0 0% 9%;
 
-    --secondary: 70 50% 25%; /* darker dashGreen light */
-    --secondary-foreground: 0 0% 100%;
+    --secondary: 0 0% 14.9%;
+    --secondary-foreground: 0 0% 98%;
 
-    --muted: 70 30% 20%;
-    --muted-foreground: 48 30% 90%;
+    --muted: 0 0% 14.9%;
+    --muted-foreground: 0 0% 63.9%;
 
-    --accent: 0 100% 60%; /* darker dashRed */
-    --accent-foreground: 0 0% 100%;
+    --accent: 0 0% 14.9%;
+    --accent-foreground: 0 0% 98%;
 
-    --destructive: 0 100% 40%;
-    --destructive-foreground: 0 0% 100%;
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 0 0% 98%;
 
-    --border: 70 30% 20%;
-    --input: 70 30% 20%;
-    --ring: 48 100% 50%;
+    --border: 0 0% 14.9%;
+    --input: 0 0% 14.9%;
+    --ring: 0 0% 83.1%;
   }
-}
 
-@layer base {
   * {
     @apply border-border;
   }
@@ -139,50 +140,6 @@
 
 
 
-@layer base {
-  :root {
-    --background: 150 30% 12%;
-    --foreground: 0 0% 98%;
-
-    --muted: 147 30% 15%;
-    --muted-foreground: 240 5% 84%;
-
-    --popover: 150 30% 12%;
-    --popover-foreground: 0 0% 98%;
-
-    --card: 146 31% 10%;
-    --card-foreground: 0 0% 98%;
-
-    --border: 146 31% 15%;
-    --input: 146 31% 15%;
-
-    --primary: 44 100% 48%;
-    --primary-foreground: 0 0% 9%;
-
-    --secondary: 146 31% 15%;
-    --secondary-foreground: 0 0% 98%;
-
-    --accent: 160 61% 43%;
-    --accent-foreground: 0 0% 9%;
-
-    --destructive: 0 84% 60%;
-    --destructive-foreground: 0 0% 98%;
-
-    --ring: 146 31% 15%;
-
-    --radius: 0.5rem;
-    
-    --dashGreen: var(--dashcoin-green);
-    --dashGreen-dark: var(--dashcoin-green-dark);
-    --dashGreen-light: var(--dashcoin-green-light);
-    --dashGreen-accent: var(--dashcoin-green-accent);
-    --dashYellow: var(--dashcoin-yellow);
-    --dashYellow-dark: var(--dashcoin-yellow-dark);
-    --dashYellow-light: var(--dashcoin-yellow-light);
-    --dashBlack: var(--dashcoin-black);
-    --dashRed: var(--dashcoin-red);
-  }
-}
 
 /* Custom scrollbar */
 ::-webkit-scrollbar {


### PR DESCRIPTION
## Summary
- merge duplicate `@layer base :root` declarations in `globals.css`
- switch to grey/black/off‑white palette and keep brand color variables

## Testing
- `npm run lint` *(fails: `next` not found)*