### PR TITLE
Implement sleek design and env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The cache admin interface is available at `/admin/cache`. This interface allows 
 - `KV_REST_API_TOKEN`: Your Upstash Redis API token
 - `ENABLE_DUNE_API`: Set to `true` to enable real Dune API calls (default: `false`)
 - `VERCEL_ENV`: Automatically set by Vercel to indicate the environment
+- `GOOGLE_API_KEY`: Google Sheets API key for token research data
 
 ## Cache Keys
 

--- a/app/actions/googlesheet-action.ts
+++ b/app/actions/googlesheet-action.ts
@@ -5,7 +5,11 @@ interface ResearchScoreData {
 }
 
 export async function fetchTokenResearch(): Promise<ResearchScoreData[]> {
-  const API_KEY = 'AIzaSyC8QxJez_UTHUJS7vFj1J3Sje0CWS9tXyk';
+  const API_KEY = process.env.GOOGLE_API_KEY;
+  if (!API_KEY) {
+    console.error('GOOGLE_API_KEY is not set');
+    return [];
+  }
   const SHEET_ID = '1Nra5QH-JFAsDaTYSyu-KocjbkZ0MATzJ4R-rUt-gLe0';
   const SHEET_NAME = 'Dashcoin Scoring';
   const RANGE = `${SHEET_NAME}!A1:K30`;

--- a/app/globals.css
+++ b/app/globals.css
@@ -34,17 +34,27 @@
 
     --radius: 0.75rem;
 
-      --font-inter: 'Inter', sans-serif;
-    --font-bangers: 'Bangers', cursive;
-    --dashcoin-yellow: #F6BE00;
-    --dashcoin-yellow-dark: #E9B200;
-    --dashcoin-yellow-light: #F9D44C;
-    --dashcoin-green: #0E1E19;
-    --dashcoin-green-dark: #0A150F;
-    --dashcoin-green-light: #1A2C24;
-    --dashcoin-green-accent: #21BB89;
-    --dashcoin-black: #121212;
-  --dashcoin-red: #F05252;
+    --font-league-spartan: 'League Spartan', sans-serif;
+    /* Updated palette: grey, black and off-white */
+    --dashcoin-yellow: #f5f5f5; /* off-white */
+    --dashcoin-yellow-dark: #e5e5e5;
+    --dashcoin-yellow-light: #fafafa;
+    --dashcoin-green: #3a3a3a; /* base grey */
+    --dashcoin-green-dark: #1a1a1a; /* near black */
+    --dashcoin-green-light: #4f4f4f;
+    --dashcoin-green-accent: #656565;
+    --dashcoin-black: #000000;
+    --dashcoin-red: #f05252;
+
+    --dashGreen: var(--dashcoin-green);
+    --dashGreen-dark: var(--dashcoin-green-dark);
+    --dashGreen-light: var(--dashcoin-green-light);
+    --dashGreen-accent: var(--dashcoin-green-accent);
+    --dashYellow: var(--dashcoin-yellow);
+    --dashYellow-dark: var(--dashcoin-yellow-dark);
+    --dashYellow-light: var(--dashcoin-yellow-light);
+    --dashBlack: var(--dashcoin-black);
+    --dashRed: var(--dashcoin-red);
   }
 
   @layer base {
@@ -97,14 +107,15 @@
 .card-with-border {
   position: relative;
   border-radius: 1rem;
-  /* overflow: hidden; */ /* Removed to allow suggestion dropdown to be visible */
-  background: rgba(42, 47, 14, 0.98); /* dashGreen-card with high opacity */
-  border: 2px solid #222222;
-  box-shadow: 0 8px 0 0 #222222, 0 0 15px rgba(0, 0, 0, 0.3);
+  background: var(--dashYellow);
+  border: 2px solid var(--dashBlack);
+  color: var(--dashBlack);
+  box-shadow: 0 8px 0 0 var(--dashBlack), 0 0 15px rgba(0, 0, 0, 0.3);
 }
 
 .dark .card-with-border {
-  background: rgba(26, 29, 8, 0.98); /* dashGreen-cardDark with high opacity */
+  background: var(--dashYellow);
+  color: var(--dashBlack);
 }
 
 .card-with-border::before {
@@ -114,75 +125,31 @@
   left: 0;
   right: 0;
   bottom: 0;
-  border: 2px solid #ffd700;
+  border: 2px solid var(--dashBlack);
   border-radius: 0.75rem;
   pointer-events: none;
 }
 
 .dashcoin-title {
-  font-family: "Bangers", system-ui, sans-serif;
-  text-shadow: 3px 3px 0 #222222;
+  font-family: "League Spartan", system-ui, sans-serif;
+  text-shadow: 3px 3px 0 var(--dashBlack);
   letter-spacing: 1px;
 }
 
 .dashcoin-title-hq {
-  font-family: "Bangers", system-ui, sans-serif;
-  text-shadow: 3px 3px 0 #222222;
+  font-family: "League Spartan", system-ui, sans-serif;
+  text-shadow: 3px 3px 0 var(--dashBlack);
   letter-spacing: 5px;
 }
 
 .dashcoin-text {
-  font-family: "Bangers", system-ui, sans-serif;
-  text-shadow: 2px 2px 0 #222222;
+  font-family: "League Spartan", system-ui, sans-serif;
+  text-shadow: 2px 2px 0 var(--dashBlack);
   letter-spacing: 1px;
 }
 
 
 
-@layer base {
-  :root {
-    --background: 150 30% 12%;
-    --foreground: 0 0% 98%;
-
-    --muted: 147 30% 15%;
-    --muted-foreground: 240 5% 84%;
-
-    --popover: 150 30% 12%;
-    --popover-foreground: 0 0% 98%;
-
-    --card: 146 31% 10%;
-    --card-foreground: 0 0% 98%;
-
-    --border: 146 31% 15%;
-    --input: 146 31% 15%;
-
-    --primary: 44 100% 48%;
-    --primary-foreground: 0 0% 9%;
-
-    --secondary: 146 31% 15%;
-    --secondary-foreground: 0 0% 98%;
-
-    --accent: 160 61% 43%;
-    --accent-foreground: 0 0% 9%;
-
-    --destructive: 0 84% 60%;
-    --destructive-foreground: 0 0% 98%;
-
-    --ring: 146 31% 15%;
-
-    --radius: 0.5rem;
-    
-    --dashGreen: var(--dashcoin-green);
-    --dashGreen-dark: var(--dashcoin-green-dark);
-    --dashGreen-light: var(--dashcoin-green-light);
-    --dashGreen-accent: var(--dashcoin-green-accent);
-    --dashYellow: var(--dashcoin-yellow);
-    --dashYellow-dark: var(--dashcoin-yellow-dark);
-    --dashYellow-light: var(--dashcoin-yellow-light);
-    --dashBlack: var(--dashcoin-black);
-    --dashRed: var(--dashcoin-red);
-  }
-}
 
 /* Custom scrollbar */
 ::-webkit-scrollbar {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,11 +1,13 @@
 import type React from "react"
 import type { Metadata } from "next"
-import { Inter, Bangers } from "next/font/google"
+import { League_Spartan } from "next/font/google"
 import { ThemeProvider } from "@/components/theme-provider"
 import "./globals.css"
 
-const inter = Inter({ subsets: ["latin"], variable: "--font-inter" })
-const bangers = Bangers({ weight: "400", subsets: ["latin"], variable: "--font-bangers" })
+const leagueSpartan = League_Spartan({
+  subsets: ["latin"],
+  variable: "--font-league-spartan",
+})
 
 export const metadata: Metadata = {
   title: "Dashcoin - Cryptocurrency Dashboard",
@@ -20,7 +22,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={`${inter.variable} ${bangers.variable} font-sans`}>
+      <body className={`${leagueSpartan.variable} font-sans`}>
         <ThemeProvider attribute="class" defaultTheme="light" enableSystem disableTransitionOnChange>
           {children}
         </ThemeProvider>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -244,30 +244,19 @@ export default async function Home() {
           <div className="flex justify-center items-center gap-4 mb-4">
             <div className="w-24 h-24 md:w-32 md:h-32 relative">
               <Image
-                src="/images/frog-soldier.png"
-                alt="Dashcoin Frog Soldier"
+                src="/images/Dashcoin%20Research%20Logo.png"
+                alt="Dashcoin Research Logo"
                 width={128}
                 height={128}
                 className="object-contain rounded-full overflow-hidden"
-                style={{ clipPath: "circle(50%)" }} 
+                style={{ clipPath: "circle(50%)" }}
               />
             </div>
             <div className="flex flex-col">
-              <h1 className="dashcoin-title-hq text-5xl md:text-8xl text-dashYellow">
-                DASHCOIN HQ
+              <h1 className="dashcoin-title-hq text-5xl md:text-8xl text-dashBlack">
+                DASHCOIN RESEARCH
               </h1>
-              <p className="text-xl">Your Research hub for tokens launched on the Believe app</p>
-            </div>
-            
-            <div className="w-24 h-24 md:w-32 md:h-32 relative">
-              <Image
-                src="/images/frog-soldier.png"
-                alt="Dashcoin Frog Soldier"
-                width={128}
-                height={128}
-                className="object-contain scale-x-[-1] rounded-full overflow-hidden"
-                style={{ clipPath: "circle(50%)" }}
-              />
+              <p className="text-xl">Your research hub for tokens launched on the Believe app</p>
             </div>
           </div>
           {/* DASHC Token Stats Row */}

--- a/app/tokendetail/[symbol]/page.tsx
+++ b/app/tokendetail/[symbol]/page.tsx
@@ -34,7 +34,11 @@ interface TokenResearchData {
 }
 
 async function fetchTokenResearch(tokenSymbol: string): Promise<TokenResearchData | null> {
-  const API_KEY = 'AIzaSyC8QxJez_UTHUJS7vFj1J3Sje0CWS9tXyk';
+  const API_KEY = process.env.GOOGLE_API_KEY;
+  if (!API_KEY) {
+    console.error('GOOGLE_API_KEY is not set');
+    return null;
+  }
   const SHEET_ID = '1Nra5QH-JFAsDaTYSyu-KocjbkZ0MATzJ4R-rUt-gLe0';
   const SHEET_NAME = 'Dashcoin Scoring';
   const RANGE = `${SHEET_NAME}!A1:M30`;

--- a/components/market-cap-chart.tsx
+++ b/components/market-cap-chart.tsx
@@ -40,8 +40,8 @@ export function MarketCapChart({ data }: MarketCapChartProps) {
         {
           label: "Market Cap (USD)",
           data: sortedData.map((item) => item.marketcap || 0),
-          borderColor: "#ffd700",
-          backgroundColor: "rgba(255, 215, 0, 0.1)",
+          borderColor: "#f5f5f5",
+          backgroundColor: "rgba(245, 245, 245, 0.1)",
           borderWidth: 2,
           fill: true,
           tension: 0.4,
@@ -49,8 +49,8 @@ export function MarketCapChart({ data }: MarketCapChartProps) {
         {
           label: "Holders",
           data: sortedData.map((item) => item.num_holders || 0),
-          borderColor: "#66cc33",
-          backgroundColor: "rgba(102, 204, 51, 0.1)",
+          borderColor: "#656565",
+          backgroundColor: "rgba(101, 101, 101, 0.1)",
           borderWidth: 2,
           fill: true,
           tension: 0.4,
@@ -68,18 +68,18 @@ export function MarketCapChart({ data }: MarketCapChartProps) {
         scales: {
           x: {
             grid: {
-              color: "rgba(42, 47, 14, 0.3)",
+              color: "rgba(60, 60, 60, 0.3)",
             },
             ticks: {
-              color: "#fff0a0",
+              color: "#3a3a3a",
             },
           },
           y: {
             grid: {
-              color: "rgba(42, 47, 14, 0.3)",
+              color: "rgba(60, 60, 60, 0.3)",
             },
             ticks: {
-              color: "#fff0a0",
+              color: "#3a3a3a",
               callback: (value: number) => formatCurrency(value),
             },
           },
@@ -89,14 +89,14 @@ export function MarketCapChart({ data }: MarketCapChartProps) {
               display: false,
             },
             ticks: {
-              color: "#66cc33",
+              color: "#656565",
             },
           },
         },
         plugins: {
           legend: {
             labels: {
-              color: "#fff0a0",
+              color: "#3a3a3a",
             },
           },
           tooltip: {

--- a/components/market-cap-pie.tsx
+++ b/components/market-cap-pie.tsx
@@ -55,16 +55,16 @@ export function MarketCapPie({ data }: MarketCapPieProps) {
     if (topTokens.length === 0) return
 
     const colors = [
-      "#ffd700", 
-      "#66cc33", 
-      "#ff6666", 
-      "#0077cc", 
-      "#99dd66", 
-      "#e6b800", 
-      "#339900", 
-      "#ff9999", 
-      "#00aaff", 
-      "#cccccc", 
+      "#f5f5f5",
+      "#656565",
+      "#ff6666",
+      "#3a3a3a",
+      "#e5e5e5",
+      "#4f4f4f",
+      "#cc3333",
+      "#fafafa",
+      "#2b2b2b",
+      "#000000",
     ]
 
     const chartData = {
@@ -89,7 +89,7 @@ export function MarketCapPie({ data }: MarketCapPieProps) {
           legend: {
             position: "right",
             labels: {
-              color: "#fff0a0",
+              color: "#3a3a3a",
               font: {
                 size: 12,
               },

--- a/components/token-table.tsx
+++ b/components/token-table.tsx
@@ -350,47 +350,47 @@ export default function TokenTable({ data }: { data: PaginatedTokenResponse | To
         <div className="overflow-x-auto">
           <table className="w-full border-collapse">
             <thead>
-              <tr className="bg-dashGreen-card dark:bg-dashGreen-cardDark border-b-2 border-dashBlack">
-                <th className="text-left py-3 px-4 text-dashYellow cursor-pointer" onClick={() => handleSort("symbol")}>
+              <tr className="bg-dashYellow border-b-2 border-dashBlack">
+                <th className="text-left py-3 px-4 text-dashBlack cursor-pointer" onClick={() => handleSort("symbol")}> 
                   <div className="flex items-center gap-1">Token {renderSortIndicator("symbol")}</div>
                 </th>
-                <th className="text-left py-3 px-4 text-dashYellow">Actions</th>
-                <th className="text-left py-3 px-4 text-dashYellow cursor-pointer" onClick={() => handleSort("name")}>
+                <th className="text-left py-3 px-4 text-dashBlack">Actions</th>
+                <th className="text-left py-3 px-4 text-dashBlack cursor-pointer" onClick={() => handleSort("name")}> 
                   <div className="flex items-center gap-1">Name {renderSortIndicator("name")}</div>
                 </th>
                 <th
-                  className="text-left py-3 px-4 text-dashYellow cursor-pointer"
+                  className="text-left py-3 px-4 text-dashBlack cursor-pointer"
                   onClick={() => handleSort("marketCap")}
                 >
                   <div className="flex items-center gap-1">Market Cap {renderSortIndicator("marketCap")}</div>
                 </th>
                 <th
-                  className="text-left py-3 px-4 text-dashYellow cursor-pointer"
+                  className="text-left py-3 px-4 text-dashBlack cursor-pointer"
                   onClick={() => handleSort("num_holders")}
                 >
                   <div className="flex items-center gap-1">Holders {renderSortIndicator("num_holders")}</div>
                 </th>
                 <th
-                  className="text-left py-3 px-4 text-dashYellow cursor-pointer"
+                  className="text-left py-3 px-4 text-dashBlack cursor-pointer"
                   onClick={() => handleSort("created_time")}
                 >
                   <div className="flex items-center gap-1">Created {renderSortIndicator("created_time")}</div>
                 </th>
-                <th 
-                  className="text-left py-3 px-4 text-dashYellow cursor-pointer"
+                <th
+                  className="text-left py-3 px-4 text-dashBlack cursor-pointer"
                   onClick={() => handleSort("researchScore")}
                 >
                   <div className="flex items-center gap-1">
                     Research Score {renderSortIndicator("researchScore")}
                   </div>
                 </th>
-                <th className="text-left py-3 px-4 text-dashYellow cursor-pointer" onClick={() => handleSort("volume24h")}>
+                <th className="text-left py-3 px-4 text-dashBlack cursor-pointer" onClick={() => handleSort("volume24h")}> 
                   <div className="flex items-center gap-1">24h Volume {renderSortIndicator("volume24h")}</div>
                 </th>
-                <th className="text-left py-3 px-4 text-dashYellow cursor-pointer" onClick={() => handleSort("change24h")}>
+                <th className="text-left py-3 px-4 text-dashBlack cursor-pointer" onClick={() => handleSort("change24h")}> 
                   <div className="flex items-center gap-1">24h %Gain {renderSortIndicator("change24h")}</div>
                 </th>
-                <th className="text-left py-3 px-4 text-dashYellow cursor-pointer" onClick={() => handleSort("changeM5")}>
+                <th className="text-left py-3 px-4 text-dashBlack cursor-pointer" onClick={() => handleSort("changeM5")}> 
                   <div className="flex items-center gap-1">5m %Gain {renderSortIndicator("changeM5")}</div>
                 </th>
               </tr>
@@ -414,10 +414,10 @@ export default function TokenTable({ data }: { data: PaginatedTokenResponse | To
                   return (
                     <tr
                       key={index}
-                      className="border-b border-dashGreen-light hover:bg-dashGreen-card dark:hover:bg-dashGreen-cardDark"
+                      className="border-b border-dashBlack hover:bg-dashYellow-light"
                     >
                       <td className="py-3 px-4">
-                        <Link href={`/tokendetail/${tokenSymbol}`} className="hover:text-dashYellow">
+                        <Link href={`/tokendetail/${tokenSymbol}`} className="hover:text-dashGreen-accent">
                           <div>
                             <p className="font-bold">{tokenSymbol}</p>
                             {tokenAddress && (
@@ -457,7 +457,7 @@ export default function TokenTable({ data }: { data: PaginatedTokenResponse | To
                         ) : researchScore !== null && researchScore !== undefined ? (
                           <div className="flex items-center">
                             <span className="font-medium mr-2">{researchScore.toFixed(1)}</span>
-                            <Link href={`/tokendetail/${tokenSymbol}`} className="hover:text-dashYellow">
+                            <Link href={`/tokendetail/${tokenSymbol}`} className="hover:text-dashGreen-accent">
                               <FileSearch className="h-4 w-4" />
                             </Link>
                           </div>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -22,23 +22,23 @@ const config = {
     extend: {
       colors: {
         dashGreen: {
-          DEFAULT: "#4b5320", 
-          dark: "#2d3214", 
-          light: "#6b7a30", 
-          accent: "#8a9a45",    
-          card: "#2a2f0e",     
-          cardDark: "#1a1d08", 
+          DEFAULT: "#3a3a3a", // base grey
+          dark: "#1a1a1a", // near black
+          light: "#4f4f4f",
+          accent: "#656565",
+          card: "#2b2b2b",
+          cardDark: "#161616",
         },
         dashYellow: {
-          DEFAULT: "#ffd700",     
-          light: "#fff0a0",     
-          dark: "#e6b800",
+          DEFAULT: "#f5f5f5", // off-white
+          light: "#fafafa",
+          dark: "#e5e5e5",
         },
         dashRed: {
-          DEFAULT: "#ff6666",  
+          DEFAULT: "#ff6666",
           dark: "#cc3333",
         },
-        dashBlack: "#222222",     
+        dashBlack: "#000000",
 
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",
@@ -80,8 +80,7 @@ const config = {
         sm: "calc(var(--radius) - 4px)",
       },
       fontFamily: {
-        sans: ["var(--font-inter)", ...fontFamily.sans],
-        bangers: ["var(--font-bangers)"],
+        sans: ["var(--font-league-spartan)", ...fontFamily.sans],
       },
       keyframes: {
         "accordion-down": {


### PR DESCRIPTION
## Summary
- move Google Sheets API key to `GOOGLE_API_KEY` env var
- consolidate root CSS variables and use League Spartan font
- restyle cards and charts with grey/black/off‑white palette
- widen token table header styles and remove duplicate hero logo
- document `GOOGLE_API_KEY` in README

## Testing
- `npm run lint` *(fails: next not found)*