### PR TITLE
Apply Inter font globally

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -34,8 +36,6 @@
 
     --radius: 0.75rem;
 
-    --font-inter: 'Inter', sans-serif;
-    --font-bangers: 'Bangers', cursive;
 
     --dashcoin-yellow: #E6E6F0;
     --dashcoin-yellow-dark: #E6E6F0;
@@ -51,6 +51,7 @@
   @layer base {
   body {
     @apply bg-dashGreen text-slate-50;
+    font-family: 'Inter', sans-serif;
   }
 }
 
@@ -92,6 +93,7 @@
   }
   body {
     @apply bg-dashGreen text-dashYellow-light dark:bg-dashGreen-dark;
+    font-family: 'Inter', sans-serif;
   }
 }
 
@@ -120,20 +122,22 @@
   pointer-events: none;
 }
 
+
 .dashcoin-title {
-  font-family: "Bangers", system-ui, sans-serif;
+  font-family: 'Inter', sans-serif;
   text-shadow: 3px 3px 0 #222222;
   letter-spacing: 1px;
 }
 
+
 .dashcoin-title-hq {
-  font-family: "Bangers", system-ui, sans-serif;
+  font-family: 'Inter', sans-serif;
   text-shadow: 3px 3px 0 #222222;
   letter-spacing: 5px;
 }
 
 .dashcoin-text {
-  font-family: "Bangers", system-ui, sans-serif;
+  font-family: 'Inter', sans-serif;
   text-shadow: 2px 2px 0 #222222;
   letter-spacing: 1px;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,11 +1,9 @@
 import type React from "react"
 import type { Metadata } from "next"
-import { Inter, Bangers } from "next/font/google"
+
 import { ThemeProvider } from "@/components/theme-provider"
 import "./globals.css"
 
-const inter = Inter({ subsets: ["latin"], variable: "--font-inter" })
-const bangers = Bangers({ weight: "400", subsets: ["latin"], variable: "--font-bangers" })
 
 export const metadata: Metadata = {
   title: "Dashcoin - Cryptocurrency Dashboard",
@@ -20,7 +18,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body className={`${inter.variable} ${bangers.variable} font-sans`}>
+      <body className="font-sans">
         <ThemeProvider attribute="class" defaultTheme="dark" enableSystem disableTransitionOnChange>
           {children}
         </ThemeProvider>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,9 +1,11 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 body {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: 'Inter', sans-serif;
 }
 
 @layer utilities {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -80,8 +80,7 @@ const config = {
         sm: "calc(var(--radius) - 4px)",
       },
       fontFamily: {
-        sans: ["var(--font-inter)", ...fontFamily.sans],
-        bangers: ["var(--font-bangers)"],
+        sans: ["Inter", ...fontFamily.sans],
       },
       keyframes: {
         "accordion-down": {


### PR DESCRIPTION
## Summary
- import Inter from Google Fonts
- remove Bangers font use and apply Inter site-wide
- set body fonts to Inter in global styles
- simplify layout font handling
- update Tailwind config to default to Inter

## Testing
- `npm run lint` *(fails: next not found)*