### PR TITLE
Modern dark theme redesign

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -91,7 +91,7 @@
     @apply border-border;
   }
   body {
-    @apply bg-dashGreen text-dashYellow-light dark:bg-dashGreen-dark;
+    @apply bg-background text-foreground font-sans;
   }
 }
 
@@ -99,13 +99,13 @@
   position: relative;
   border-radius: 1rem;
   /* overflow: hidden; */ /* Removed to allow suggestion dropdown to be visible */
-  background: rgba(42, 47, 14, 0.98); /* dashGreen-card with high opacity */
-  border: 2px solid #222222;
-  box-shadow: 0 8px 0 0 #222222, 0 0 15px rgba(0, 0, 0, 0.3);
+  background: #1B1B26;
+  border: 1px solid #2A2A35;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.4);
 }
 
 .dark .card-with-border {
-  background: rgba(26, 29, 8, 0.98); /* dashGreen-cardDark with high opacity */
+  background: #1B1B26;
 }
 
 .card-with-border::before {
@@ -115,7 +115,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  border: 2px solid var(--dashYellow);
+  border: 1px solid var(--dashYellow);
   border-radius: 0.75rem;
   pointer-events: none;
 }

--- a/components/market-cap-chart.tsx
+++ b/components/market-cap-chart.tsx
@@ -34,9 +34,9 @@ export function MarketCapChart({ data }: MarketCapChartProps) {
       return dateA - dateB
     })
 
-    const dashYellow = getCssVariable("--dashYellow") || "#ffd700"
-    const dashYellowLight = getCssVariable("--dashYellow-light") || "#fff0a0"
-    const dashGreen = getCssVariable("--dashGreen-accent") || "#66cc33"
+    const dashYellow = "#50E3C2"
+    const dashYellowLight = "#A0A0B0"
+    const dashGreen = "#6A8DFF"
 
     const chartData = {
       labels: sortedData.map((item) => (item.date ? new Date(item.date).toLocaleDateString() : "Unknown")),
@@ -151,7 +151,7 @@ export function MarketCapChart({ data }: MarketCapChartProps) {
         <DashcoinCardTitle>Market Cap & Holders Over Time</DashcoinCardTitle>
       </DashcoinCardHeader>
       <DashcoinCardContent>
-        <div className="h-80">
+        <div className="h-80 bg-[#13131A]">
           <canvas ref={chartRef} />
         </div>
         <DuneQueryLink queryId={5119241} className="mt-2" />

--- a/components/market-cap-pie.tsx
+++ b/components/market-cap-pie.tsx
@@ -54,21 +54,21 @@ export function MarketCapPie({ data }: MarketCapPieProps) {
 
     if (topTokens.length === 0) return
 
-    const dashYellow = getCssVariable("--dashYellow") || "#ffd700"
-    const dashGreen = getCssVariable("--dashGreen-accent") || "#66cc33"
-    const dashYellowLight = getCssVariable("--dashYellow-light") || "#fff0a0"
+    const dashYellow = "#50E3C2"
+    const dashGreen = "#6A8DFF"
+    const dashYellowLight = "#A0A0B0"
 
     const colors = [
       dashYellow,
       dashGreen,
-      "#ff6666",
-      "#0077cc",
-      "#99dd66",
-      "#e6b800",
-      "#339900",
-      "#ff9999", 
-      "#00aaff", 
-      "#cccccc", 
+      "#BD7BFF",
+      "#FFA45B",
+      "#8E87E1",
+      "#39C0FA",
+      "#C28AFF",
+      "#FF6B8A",
+      "#5ED9B7",
+      "#A0A0B0",
     ]
 
     const chartData = {
@@ -77,7 +77,7 @@ export function MarketCapPie({ data }: MarketCapPieProps) {
         {
           data: topTokens.map((item) => item.market_cap_usd || 0),
           backgroundColor: colors.slice(0, topTokens.length),
-          borderColor: "#222222",
+          borderColor: "#2A2A35",
           borderWidth: 2,
         },
       ],
@@ -121,7 +121,7 @@ export function MarketCapPie({ data }: MarketCapPieProps) {
         <DashcoinCardTitle>Market Cap Distribution</DashcoinCardTitle>
       </DashcoinCardHeader>
       <DashcoinCardContent>
-        <div className="h-80">
+        <div className="h-80 bg-[#13131A]">
           <canvas ref={chartRef} />
         </div>
         <DuneQueryLink queryId={5140151} className="mt-2" />

--- a/components/ui/dashcoin-card.tsx
+++ b/components/ui/dashcoin-card.tsx
@@ -15,7 +15,14 @@ DashcoinCardHeader.displayName = "DashcoinCardHeader"
 
 const DashcoinCardTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
   ({ className, ...props }, ref) => (
-    <h3 ref={ref} className={cn("dashcoin-text text-xl text-dashYellow", className)} {...props} />
+    <h3
+      ref={ref}
+      className={cn(
+        "dashcoin-text text-xl font-semibold text-dashYellow",
+        className,
+      )}
+      {...props}
+    />
   ),
 )
 DashcoinCardTitle.displayName = "DashcoinCardTitle"

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -3,7 +3,7 @@
 @tailwind utilities;
 
 body {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-inter);
 }
 
 @layer utilities {


### PR DESCRIPTION
## Summary
- update global styles for Inter font and dark card look
- tune card title weight and colors
- refresh chart colors with neon palette
- add dark backgrounds for charts

## Testing
- `npm run lint` *(fails: next not found)*