### PR TITLE
Switch to Dexscreener market cap

### DIFF
--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Twitter, BarChart2, Users, ArrowRight, InfoIcon, Loader2, ArrowLeftRight } from "lucide-react";
 import { DashcoinLogo } from "@/components/dashcoin-logo";
 import { GrowthStatCard } from "@/components/ui/growth-stat-card";
+import { batchFetchTokensData } from "@/app/actions/dexscreener-actions";
 
 import { BarChart as RechartsBarChart, Bar, XAxis, YAxis, Tooltip, Legend, ResponsiveContainer } from 'recharts';
 
@@ -175,7 +176,7 @@ export default function ComparePage() {
     };
   };
 
-  const handleCompare = () => {
+  const handleCompare = async () => {
     setIsLoading(true);
     setError(null);
     try {
@@ -201,6 +202,21 @@ export default function ComparePage() {
         setIsLoading(false);
         return;
       }
+      try {
+        const dexMap = await batchFetchTokensData([token1.token, token2.token]);
+        const dex1 = dexMap.get(token1.token);
+        const dex2 = dexMap.get(token2.token);
+
+        if (dex1 && dex1.pairs && dex1.pairs.length > 0) {
+          token1.marketCap = dex1.pairs[0].fdv ?? token1.marketCap;
+        }
+        if (dex2 && dex2.pairs && dex2.pairs.length > 0) {
+          token2.marketCap = dex2.pairs[0].fdv ?? token2.marketCap;
+        }
+      } catch (err) {
+        console.error('Error fetching Dexscreener data for compare:', err);
+      }
+
       const token1Data = convertTokenData(token1);
       const token2Data = convertTokenData(token2);
 

--- a/app/token/[symbol]/page.tsx
+++ b/app/token/[symbol]/page.tsx
@@ -121,7 +121,7 @@ export default function TokenPage({ params }: { params: { symbol: string } }) {
   const tokenName = tokenData?.name || tokenData?.description || "Unknown Token"
   const tokenAddress = tokenData?.token || ""
   const createdTime = tokenData?.created_time ? new Date(tokenData.created_time).toLocaleDateString() : "Unknown"
-  const marketCap = tokenData?.marketCap || 0
+  const marketCap = dexscreenerData?.fdv || tokenData?.marketCap || 0
 
   return (
     <div className="min-h-screen">

--- a/app/tokendetail/[symbol]/page.tsx
+++ b/app/tokendetail/[symbol]/page.tsx
@@ -189,7 +189,7 @@ export default function TokenResearchPage({ params }: { params: { symbol: string
     const tokenName = tokenData?.name || tokenData?.description || "Unknown Token"
     const tokenAddress = tokenData?.token || ""
     const createdTime = tokenData?.created_time ? new Date(tokenData.created_time).toLocaleDateString() : "Unknown"
-    const marketCap = tokenData?.marketCap || 0
+    const marketCap = dexscreenerData?.fdv || tokenData?.marketCap || 0
 
   const frameworkCriteria = [
     "Founder Doxxed",


### PR DESCRIPTION
## Summary
- sort tokens using Dexscreener market caps
- enrich token market cap data for pie chart
- show Dexscreener market caps on token detail pages
- include Dexscreener data when comparing tokens

## Testing
- `npm run lint` *(fails: `next` not found)*