### PR TITLE
Improve data caching and enable ISR

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -27,6 +27,8 @@ import { DuneQueryLink } from "@/components/dune-query-link";
 import { Navbar } from "@/components/navbar";
 import { Twitter } from "lucide-react";
 
+export const revalidate = 60;
+
 const MarketCapChartWrapper = async ({
   marketCapTimeDataPromise,
 }: {


### PR DESCRIPTION
## Summary
- enable ISR on the homepage so data is regenerated every 60s instead of only at build time
- cache results inside `batchFetchTokensData` to avoid repeated Dexscreener API calls

## Testing
- `pnpm run build` *(fails: `next` not found)*