### PR TITLE
Remove width restriction from container

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -13,11 +13,9 @@ const config = {
   prefix: "",
   theme: {
     container: {
-      center: true,
-      padding: "2rem",
-      screens: {
-        "2xl": "1400px",
-      },
+      center: false,
+      padding: "0",
+      screens: {},
     },
     extend: {
       colors: {


### PR DESCRIPTION
## Summary
- disable centering and max-width on the Tailwind `container`
- remove default container padding so content can stretch edge-to-edge

## Testing
- `npm run lint` *(fails: `next` not found)*