### PR TITLE
Fix Google Sheets fetch on server

### DIFF
--- a/app/actions/googlesheet-action.ts
+++ b/app/actions/googlesheet-action.ts
@@ -1,7 +1,9 @@
-interface ResearchScoreData {
+"use server";
+
+export interface ResearchScoreData {
   symbol: string
   score: number | null
-  [key: string]: any 
+  [key: string]: any
 }
 
 export async function fetchTokenResearch(): Promise<ResearchScoreData[]> {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -26,6 +26,7 @@ import { CopyAddress } from "@/components/copy-address";
 import { DuneQueryLink } from "@/components/dune-query-link";
 import { Navbar } from "@/components/navbar";
 import { Twitter } from "lucide-react";
+import { fetchTokenResearch } from "./actions/googlesheet-action";
 
 const MarketCapChartWrapper = async ({
   marketCapTimeDataPromise,
@@ -70,6 +71,7 @@ const TokenTableWrapper = async ({
 }) => {
   try {
     const tokenData = await tokenDataPromise;
+    const researchScores = await fetchTokenResearch();
     return (
       <TokenTable
         data={
@@ -81,6 +83,7 @@ const TokenTableWrapper = async ({
             totalPages: 1,
           }
         }
+        researchScores={researchScores}
       />
     );
   } catch (error) {


### PR DESCRIPTION
## Summary
- make `fetchTokenResearch` a server action
- prefetch research scores in `TokenTableWrapper`
- pass research score data down to `<TokenTable>`
- remove client-side fetching in `TokenTable`

## Testing
- `npx --yes next lint` *(fails: request to https://registry.npmjs.org/next failed)*