### PR TITLE
Fix Google Sheets integration

### DIFF
--- a/app/actions/googlesheet-action.ts
+++ b/app/actions/googlesheet-action.ts
@@ -1,7 +1,9 @@
+"use server";
+
 interface ResearchScoreData {
   symbol: string
   score: number | null
-  [key: string]: any 
+  [key: string]: any
 }
 
 export async function fetchTokenResearch(): Promise<ResearchScoreData[]> {
@@ -40,4 +42,11 @@ export async function fetchTokenResearch(): Promise<ResearchScoreData[]> {
     console.error('Google Sheets API error:', err);
     return [];
   }
+}
+
+export async function fetchTokenResearchBySymbol(symbol: string): Promise<ResearchScoreData | null> {
+  const allData = await fetchTokenResearch();
+  const normalized = symbol.toUpperCase();
+  const entry = allData.find(item => item.symbol.toUpperCase() === normalized && item.score !== null);
+  return entry || null;
 }

--- a/app/api/token-research/[symbol]/route.ts
+++ b/app/api/token-research/[symbol]/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+import { fetchTokenResearchBySymbol } from '@/app/actions/googlesheet-action';
+
+export async function GET(
+  request: Request,
+  { params }: { params: { symbol: string } }
+) {
+  try {
+    const data = await fetchTokenResearchBySymbol(params.symbol);
+    if (!data) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    }
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('Error fetching token research:', error);
+    return NextResponse.json({ error: 'Failed to fetch token research' }, { status: 500 });
+  }
+}

--- a/app/api/token-research/route.ts
+++ b/app/api/token-research/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server';
+import { fetchTokenResearch } from '@/app/actions/googlesheet-action';
+
+export async function GET() {
+  try {
+    const data = await fetchTokenResearch();
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('Error fetching token research:', error);
+    return new NextResponse(JSON.stringify({ error: 'Failed to fetch token research' }), {
+      status: 500,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+  }
+}

--- a/app/tokendetail/[symbol]/page.tsx
+++ b/app/tokendetail/[symbol]/page.tsx
@@ -34,39 +34,14 @@ interface TokenResearchData {
 }
 
 async function fetchTokenResearch(tokenSymbol: string): Promise<TokenResearchData | null> {
-  const API_KEY = process.env.GOOGLE_API_KEY;
-  const SHEET_ID = '1Nra5QH-JFAsDaTYSyu-KocjbkZ0MATzJ4R-rUt-gLe0';
-  const SHEET_NAME = 'Dashcoin Scoring';
-  const RANGE = `${SHEET_NAME}!A1:M30`;
-  const url = `https://sheets.googleapis.com/v4/spreadsheets/${SHEET_ID}/values/${RANGE}?key=${API_KEY}`;
-
   try {
-    const response = await fetch(url);
-    const data = await response.json();
-    
-    if (!data.values || data.values.length < 2) {
-      console.warn('No data found in Google Sheet');
+    const response = await fetch(`/api/token-research/${encodeURIComponent(tokenSymbol)}`);
+    if (!response.ok) {
+      console.error('Failed to fetch token research:', await response.text());
       return null;
     }
-
-    const [header, ...rows] = data.values;
-    
-    const structured = rows.map((row: any) => {
-      const entry: Record<string, any> = {};
-      header.forEach((key: string, i: number) => {
-        entry[key.trim()] = row[i] || '';
-      });
-      return entry;
-    });
-
-    const normalizedSymbol = tokenSymbol.toUpperCase();
-    const tokenData = structured.find((entry: any) => 
-      entry['Project'] && 
-      entry['Project'].toString().toUpperCase() === normalizedSymbol &&
-      entry['Score'] 
-    );
-    
-    return tokenData || null;
+    const data = await response.json();
+    return data || null;
   } catch (err) {
     console.error('Google Sheets API error:', err);
     return null;

--- a/components/token-table.tsx
+++ b/components/token-table.tsx
@@ -11,7 +11,6 @@ import { CopyAddress } from "@/components/copy-address"
 import { DuneQueryLink } from "@/components/dune-query-link"
 import { batchFetchTokensData } from "@/app/actions/dexscreener-actions"
 import { useCallback } from "react"
-import { fetchTokenResearch } from "@/app/actions/googlesheet-action"
 
 interface ResearchScoreData {
   symbol: string
@@ -43,15 +42,20 @@ export default function TokenTable({ data }: { data: PaginatedTokenResponse | To
     const getResearchScores = async () => {
       setIsLoadingResearch(true);
       try {
-        const scores = await fetchTokenResearch();
-        setResearchScores(scores);
+        const response = await fetch('/api/token-research');
+        if (response.ok) {
+          const scores = await response.json();
+          setResearchScores(scores);
+        } else {
+          console.error('Error fetching research scores:', await response.text());
+        }
       } catch (error) {
         console.error("Error fetching research scores:", error);
       } finally {
         setIsLoadingResearch(false);
       }
     };
-    
+
     getResearchScores();
   }, []);
 


### PR DESCRIPTION
## Summary
- ensure google sheets actions run on server only
- add API routes for token research data
- fetch research data via API in client components

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*