### PR TITLE
Fix dropdown hover and nav order

### DIFF
--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -349,7 +349,7 @@ export default function ComparePage() {
                         <div 
                           key={token.token} 
                           onClick={() => handleSuggestionClick(token.token, setToken1Name, setToken1Suggestions, setShowToken1Suggestions)}
-                          className="px-4 py-2 text-dashBlack hover:bg-yellow-500 hover:text-white cursor-pointer"
+                          className="px-4 py-2 text-dashBlack hover:bg-dashYellow-light hover:text-dashBlack cursor-pointer"
                         >
                           {token.name} ({token.symbol})
                           <div className="text-xs opacity-70 truncate">{token.token}</div>
@@ -371,7 +371,7 @@ export default function ComparePage() {
                         <div 
                           key={token.token} 
                           onClick={() => handleSuggestionClick(token.token, setToken2Name, setToken2Suggestions, setShowToken2Suggestions)}
-                          className="px-4 py-2 text-dashBlack hover:bg-yellow-500 hover:text-white cursor-pointer"
+                          className="px-4 py-2 text-dashBlack hover:bg-dashYellow-light hover:text-dashBlack cursor-pointer"
                         >
                           {token.name} ({token.symbol})
                           <div className="text-xs opacity-70 truncate">{token.token}</div>

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -30,6 +30,7 @@ export function Navbar({ dashcoinTradeLink }: NavbarProps) {
           </a>
         </div>
         <div className="flex items-center gap-8">
+          <ThemeToggle />
           <nav className="hidden md:flex items-center gap-6">
             <NavLink href="/" active={pathname === "/"}>
               Overview
@@ -41,7 +42,6 @@ export function Navbar({ dashcoinTradeLink }: NavbarProps) {
               Graphs & Comparisons
             </NavLink>
           </nav>
-          <ThemeToggle />
         </div>
       </div>
       {/* Mobile Navigation */}


### PR DESCRIPTION
## Summary
- lighten dropdown hover color in token suggestions
- move nav links to the far right of the header

## Testing
- `npm run lint` *(fails: `next` not found)*