### PR TITLE
Reposition and redesign framework score section

### DIFF
--- a/app/tokendetail/[symbol]/page.tsx
+++ b/app/tokendetail/[symbol]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react"
 import { useRouter } from "next/navigation"
-import { Loader2, ArrowLeft, Twitter } from "lucide-react"
+import { Loader2, ArrowLeft, Twitter, CheckCircle, XCircle } from "lucide-react"
 import { DashcoinButton } from "@/components/ui/dashcoin-button"
 import { DashcoinLogo } from "@/components/dashcoin-logo"
 import { DashcoinCard, DashcoinCardHeader, DashcoinCardTitle, DashcoinCardContent } from "@/components/ui/dashcoin-card"
@@ -189,7 +189,11 @@ export default function TokenResearchPage({ params }: { params: { symbol: string
     const tokenName = tokenData?.name || tokenData?.description || "Unknown Token"
     const tokenAddress = tokenData?.token || ""
     const createdTime = tokenData?.created_time ? new Date(tokenData.created_time).toLocaleDateString() : "Unknown"
-    const marketCap = tokenData?.marketCap || 0
+  const marketCap = tokenData?.marketCap || 0
+
+  const numericScore = researchData ? parseFloat(String(researchData.Score)) : 0
+  const scoreOutOf100 = Math.round(numericScore * 10)
+  const borderColor = scoreOutOf100 >= 70 ? "border-dashGreen-light" : "border-dashRed"
 
   const frameworkCriteria = [
     "Founder Doxxed",
@@ -264,6 +268,46 @@ export default function TokenResearchPage({ params }: { params: { symbol: string
             </a>
           </div>
         </div>
+
+        {isLoading ? (
+          <div className="flex justify-center py-12">
+            <div className="flex flex-col items-center">
+              <Loader2 className="h-8 w-8 animate-spin text-dashYellow" />
+              <p className="mt-4 text-dashYellow-light">Loading research data...</p>
+            </div>
+          </div>
+        ) : !hasScore ? (
+          <div className="p-8 text-center bg-zinc-900 border border-dashGreen-light rounded-2xl shadow-lg">
+            <h2 className="text-xl font-semibold text-dashYellow">No Research Available</h2>
+            <p className="mt-4 text-dashYellow-light">
+              Research data is not yet available for {symbol}. Check back later or try another token.
+            </p>
+          </div>
+        ) : (
+          <div className={`relative bg-zinc-900 p-6 rounded-2xl shadow-lg border ${borderColor}`}>
+            <h2 className="text-2xl font-semibold text-white">Founder’s Edge Checklist</h2>
+            <p className="text-sm text-gray-400 mt-1">Signal-based checklist of founder credibility and product traction.</p>
+            <div className="absolute top-4 right-4 bg-dashYellow text-black px-3 py-1 rounded-full text-sm font-semibold shadow">
+              Score: {scoreOutOf100} / 100
+            </div>
+            <div className="grid grid-cols-2 md:grid-cols-3 gap-4 mt-6">
+              {frameworkCriteria.map((criterion) => {
+                const value = researchData?.[criterion]
+                const numValue = typeof value === 'string' ? parseInt(value) : value
+                return (
+                  <div key={criterion} className="flex items-center gap-2 px-3 py-2 rounded-md bg-zinc-800 border border-zinc-700 text-sm text-white">
+                    {numValue === 1 ? (
+                      <CheckCircle className="text-green-500 w-4 h-4" />
+                    ) : (
+                      <XCircle className="text-red-500 w-4 h-4" />
+                    )}
+                    {criterion}
+                  </div>
+                )
+              })}
+            </div>
+          </div>
+        )}
 
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
           <DashcoinCard>
@@ -404,97 +448,6 @@ export default function TokenResearchPage({ params }: { params: { symbol: string
         {/* Dexscreener Chart */}
         {chartAddress && <DexscreenerChart tokenAddress={chartAddress} title="Price Chart" />}
       </main>
-
-      {/* Page header */}
-      <div className="mb-8">
-        <h2 className="flex items-center text-center justify-center dashcoin-text text-5xl text-dashYellow items center mt-8 mb-8">
-            "FrameWork Score" table
-        </h2>
-      </div>
-
-      {isLoading ? (
-        <div className="flex justify-center py-12">
-          <div className="flex flex-col items-center">
-            <Loader2 className="h-8 w-8 animate-spin text-dashYellow" />
-            <p className="mt-4 text-dashYellow-light">Loading research data...</p>
-          </div>
-        </div>
-      ) : !hasScore ? (
-        <DashcoinCard className="p-8 text-center">
-          <h2 className="text-xl font-semibold text-dashYellow">No Research Available</h2>
-          <p className="mt-4 text-dashYellow-light">
-            Research data is not yet available for {symbol}. Check back later or try another token.
-          </p>
-        </DashcoinCard>
-      ) : (
-        <div className="space-y-8">
-          {/* Research Score */}
-          <DashcoinCard className="p-6">
-            <div className="flex flex-col md:flex-row justify-between items-center mb-6">
-              <h2 className="text-xl font-semibold text-dashYellow mb-4 md:mb-0">Research Score</h2>
-              <div className="flex items-center">
-                <div className="text-4xl font-bold text-dashYellow">
-                  {typeof researchData?.Score === 'string' 
-                    ? parseFloat(researchData.Score).toFixed(1) 
-                    : researchData?.Score.toFixed(1)}
-                </div>
-                <div className="text-dashYellow-light ml-3">/ 10.0</div>
-              </div>
-            </div>
-            
-            {/* Framework Score Table */}
-            <h3 className="text-lg font-medium text-dashYellow mb-4">Framework Criteria</h3>
-            <div className="overflow-x-auto">
-              <table className="w-full border-collapse">
-                <thead>
-                  <tr className="bg-dashGreen-card dark:bg-dashGreen-cardDark border-b-2 border-dashBlack">
-                    {frameworkCriteria.map((criterion) => (
-                      <th key={criterion} className="py-3 px-4 text-dashYellow text-center">
-                        {criterion}
-                      </th>
-                    ))}
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr className="border-b border-dashGreen-light">
-                    {frameworkCriteria.map((criterion) => {
-                      const value = researchData?.[criterion];
-                      const numValue = typeof value === 'string' ? parseInt(value) : value;
-                      
-                      return (
-                        <td key={criterion} className="py-4 px-4 text-center border-r border-dashGreen-light last:border-r-0">
-                          <div className="text-2xl">
-                            {numValue === 1 ? (
-                              <span className="text-green-500">✅</span>
-                            ) : (
-                              <span className="text-red-500">❌</span>
-                            )}
-                          </div>
-                        </td>
-                      );
-                    })}
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-
-            {/* Twitter Button - Only if Twitter handle exists */}
-            {researchData?.Twitter && (
-              <div className="mt-8 flex justify-end">
-                <a
-                  href={`${researchData.Twitter.replace('@', '')}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="bg-[#1DA1F2] hover:bg-[#1a91da] text-white px-4 py-2 rounded-md flex items-center transition-colors"
-                >
-                  <Twitter className="h-4 w-4 mr-2" />
-                  View on Twitter
-                </a>
-              </div>
-            )}
-          </DashcoinCard>
-        </div>
-      )}
 
       <footer className="container mx-auto py-8 px-4 mt-12 border-t border-dashGreen-light">
         <div className="flex flex-col md:flex-row justify-between items-center gap-4">


### PR DESCRIPTION
## Summary
- redesign "Framework Score" into "Founder's Edge Checklist"
- move checklist to top of token detail page and show score badge

## Testing
- `npm run lint` *(fails: `next` not found)*