### PR TITLE
Add admin HTML editor

### DIFF
--- a/app/api/articles/[id]/route.ts
+++ b/app/api/articles/[id]/route.ts
@@ -1,12 +1,17 @@
 import { NextRequest, NextResponse } from 'next/server';
 import dbConnect from '@/lib/mongodb';
 import Article from '@/models/Article';
+import { verifyAdminToken } from '@/app/api/admin/login/route';
 
 export async function DELETE(
   request: NextRequest,
   { params }: { params: { id: string } }
 ) {
   try {
+    const isAdmin = await verifyAdminToken(request);
+    if (!isAdmin) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
     await dbConnect();
     
     const article = await Article.findByIdAndDelete(params.id);
@@ -27,6 +32,10 @@ export async function PATCH(
   { params }: { params: { id: string } }
 ) {
   try {
+    const isAdmin = await verifyAdminToken(request);
+    if (!isAdmin) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
     const body = await request.json();
     await dbConnect();
     

--- a/app/api/articles/route.ts
+++ b/app/api/articles/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, NextRequest } from 'next/server';
 import dbConnect from '@/lib/mongodb';
-import Article from '@/models/Article'; 
+import Article from '@/models/Article';
+import { verifyAdminToken } from '@/app/api/admin/login/route';
 
 export async function GET() {
   try {
@@ -15,12 +16,17 @@ export async function GET() {
 
 export async function POST(request: NextRequest) {
   try {
+    const isAdmin = await verifyAdminToken(request);
+    if (!isAdmin) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
     const body = await request.json();
     await dbConnect();
-    
+
     const article = new Article(body);
     await article.save();
-    
+
     return NextResponse.json(article, { status: 201 });
   } catch (error) {
     console.error('Error creating article:', error);


### PR DESCRIPTION
## Summary
- add title and coin editing states
- persist article image upload via PATCH
- gate article mutation routes behind admin token
- allow admin to update article title and coin name

## Testing
- `npx next lint` *(fails: next not found)*
- `npx tsc --noEmit` *(fails: missing dependencies)*