### PR TITLE
Add Founder's Edge Checklist

### DIFF
--- a/app/tokendetail/[symbol]/page.tsx
+++ b/app/tokendetail/[symbol]/page.tsx
@@ -26,15 +26,16 @@ import { ExternalLink } from "lucide-react";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { CopyAddress } from "@/components/copy-address";
+import { FoundersEdgeChecklist } from "@/components/founders-edge-checklist";
 
 interface TokenResearchData {
   Symbol: string;
   Score: number | string;
   "Founder Doxxed": number | string;
-  "Startup Experience": number | string;
+  "Dev is Active on Twitter": number | string;
   "Successful Exit": number | string;
   "Discussed Plans for Token Integration": number | string;
-  "Project Has Some Virality / Popularity": number | string;
+  "Project has 200k+ views on Social Media": number | string;
   "Live Product Exists": number | string;
   "Relevant Links": string;
   Comments: string;
@@ -64,11 +65,22 @@ async function fetchTokenResearch(
 
     const [header, ...rows] = data.values;
 
+    const canonicalMap: Record<string, string> = {
+      "Startup Experience": "Dev is Active on Twitter",
+      "Project Has Some Virality / Popularity":
+        "Project has 200k+ views on Social Media",
+    };
+
     const structured = rows.map((row: any) => {
       const entry: Record<string, any> = {};
       header.forEach((key: string, i: number) => {
-        entry[key.trim()] = row[i] || "";
+        const trimmed = key.trim();
+        const canonical = canonicalMap[trimmed] || trimmed;
+        entry[canonical] = row[i] || "";
       });
+      if (entry["Project"]) {
+        entry["Project"] = entry["Project"].toString().trim().toUpperCase();
+      }
       return entry;
     });
 
@@ -227,14 +239,6 @@ export default function TokenResearchPage({
     : "Unknown";
   const marketCap = tokenData?.marketCap || 0;
 
-  const frameworkCriteria = [
-    "Founder Doxxed",
-    "Startup Experience",
-    "Successful Exit",
-    "Discussed Plans for Token Integration",
-    "Project Has Some Virality / Popularity",
-    "Live Product Exists",
-  ];
 
   return (
     <div className="container mx-auto px-4 py-6">
@@ -313,6 +317,10 @@ export default function TokenResearchPage({
             </a>
           </div>
         </div>
+
+        {researchData && (
+          <FoundersEdgeChecklist data={researchData} />
+        )}
 
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
           <DashcoinCard>
@@ -476,12 +484,6 @@ export default function TokenResearchPage({
         )}
       </main>
 
-      {/* Page header */}
-      <div className="mb-8">
-        <h2 className="flex items-center text-center justify-center dashcoin-text text-5xl text-dashYellow items center mt-8 mb-8">
-          "FrameWork Score" table
-        </h2>
-      </div>
 
       {isLoading ? (
         <div className="flex justify-center py-12">
@@ -504,82 +506,20 @@ export default function TokenResearchPage({
         </DashcoinCard>
       ) : (
         <div className="space-y-8">
-          {/* Research Score */}
-          <DashcoinCard className="p-6">
-            <div className="flex flex-col md:flex-row justify-between items-center mb-6">
-              <h2 className="text-xl font-semibold text-dashYellow mb-4 md:mb-0">
-                Research Score
-              </h2>
-              <div className="flex items-center">
-                <div className="text-4xl font-bold text-dashYellow">
-                  {typeof researchData?.Score === "string"
-                    ? parseFloat(researchData.Score).toFixed(1)
-                    : researchData?.Score.toFixed(1)}
-                </div>
-                <div className="text-dashYellow-light ml-3">/ 10.0</div>
-              </div>
+          <FoundersEdgeChecklist data={researchData} showLegend />
+          {researchData?.Twitter && (
+            <div className="flex justify-end">
+              <a
+                href={`${researchData.Twitter.replace("@", "")}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="bg-[#1DA1F2] hover:bg-[#1a91da] text-white px-4 py-2 rounded-md flex items-center transition-colors"
+              >
+                <Twitter className="h-4 w-4 mr-2" />
+                View on Twitter
+              </a>
             </div>
-
-            {/* Framework Score Table */}
-            <h3 className="text-lg font-medium text-dashYellow mb-4">
-              Framework Criteria
-            </h3>
-            <div className="overflow-x-auto">
-              <table className="w-full border-collapse">
-                <thead>
-                  <tr className="bg-dashGreen-card dark:bg-dashGreen-cardDark border-b-2 border-dashBlack">
-                    {frameworkCriteria.map((criterion) => (
-                      <th
-                        key={criterion}
-                        className="py-3 px-4 text-dashYellow text-center"
-                      >
-                        {criterion}
-                      </th>
-                    ))}
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr className="border-b border-dashGreen-light">
-                    {frameworkCriteria.map((criterion) => {
-                      const value = researchData?.[criterion];
-                      const numValue =
-                        typeof value === "string" ? parseInt(value) : value;
-
-                      return (
-                        <td
-                          key={criterion}
-                          className="py-4 px-4 text-center border-r border-dashGreen-light last:border-r-0"
-                        >
-                          <div className="text-2xl">
-                            {numValue === 1 ? (
-                              <span className="text-green-500">✅</span>
-                            ) : (
-                              <span className="text-red-500">❌</span>
-                            )}
-                          </div>
-                        </td>
-                      );
-                    })}
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-
-            {/* Twitter Button - Only if Twitter handle exists */}
-            {researchData?.Twitter && (
-              <div className="mt-8 flex justify-end">
-                <a
-                  href={`${researchData.Twitter.replace("@", "")}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="bg-[#1DA1F2] hover:bg-[#1a91da] text-white px-4 py-2 rounded-md flex items-center transition-colors"
-                >
-                  <Twitter className="h-4 w-4 mr-2" />
-                  View on Twitter
-                </a>
-              </div>
-            )}
-          </DashcoinCard>
+          )}
         </div>
       )}
 

--- a/components/founders-edge-checklist.tsx
+++ b/components/founders-edge-checklist.tsx
@@ -1,0 +1,64 @@
+import { DashcoinCard } from "@/components/ui/dashcoin-card";
+import { CheckCircle, XCircle, MinusCircle } from "lucide-react";
+import React from "react";
+
+export const canonicalChecklist = [
+  "Founder Doxxed",
+  "Dev is Active on Twitter",
+  "Successful Exit",
+  "Discussed Plans for Token Integration",
+  "Project has 200k+ views on Social Media",
+  "Live Product Exists",
+];
+
+function getIcon(value: number) {
+  switch (value) {
+    case 2:
+      return <CheckCircle className="text-green-500 w-5 h-5" />;
+    case 1:
+      return <XCircle className="text-red-500 w-5 h-5" />;
+    default:
+      return <MinusCircle className="text-yellow-400 w-5 h-5" />;
+  }
+}
+
+interface ChecklistProps {
+  data: Record<string, any>;
+  showLegend?: boolean;
+}
+
+export function FoundersEdgeChecklist({ data, showLegend = false }: ChecklistProps) {
+  if (!data) return null;
+  const score = Number(data["Score"]) || 0;
+  const borderColor =
+    score >= 70 ? "border-green-500" : score >= 40 ? "border-yellow-500" : "border-red-500";
+
+  return (
+    <DashcoinCard className={`relative bg-zinc-900 p-8 rounded-2xl shadow-lg ${borderColor}`}>\
+      <div className="absolute top-4 right-4 bg-dashYellow text-black px-3 py-1 rounded-full text-sm font-semibold shadow">
+        Score: <span className="font-bold">{score}</span> / 100
+      </div>
+      <h2 className="text-xl font-semibold text-dashYellow mb-1">Founder&apos;s Edge Checklist</h2>
+      <p className="text-sm opacity-80 mb-4">Signal-based checklist of founder credibility and product traction.</p>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+        {canonicalChecklist.map((label) => {
+          const raw = data[label];
+          const val = typeof raw === "string" ? parseInt(raw) : Number(raw);
+          return (
+            <div key={label} className="flex items-center gap-2 bg-zinc-800 rounded-full px-3 py-2">
+              {getIcon(val)}
+              <span className="text-sm">{label}</span>
+            </div>
+          );
+        })}
+      </div>
+      {showLegend && (
+        <div className="mt-4 flex items-center gap-4 text-sm">
+          <div className="flex items-center gap-1"><MinusCircle className="text-yellow-400 w-4 h-4" /> Unknown</div>
+          <div className="flex items-center gap-1"><XCircle className="text-red-500 w-4 h-4" /> No</div>
+          <div className="flex items-center gap-1"><CheckCircle className="text-green-500 w-4 h-4" /> Yes</div>
+        </div>
+      )}
+    </DashcoinCard>
+  );
+}


### PR DESCRIPTION
## Summary
- normalize research column labels when fetching from Google Sheets
- add `FoundersEdgeChecklist` component for standardized checklist display
- show checklist near token header and again with legend at bottom

## Testing
- `npm run lint` *(fails: next not found)*