### PR TITLE
Add Founder's Edge Checklist

### DIFF
--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -92,7 +92,6 @@ const CustomTooltip = ({ active, payload, label }: any) => {
 };
 
 export default function ComparePage() {
-  const dashcoinTradeLink = "https://axiom.trade/t/fRfKGCriduzDwSudCwpL7ySCEiboNuryhZDVJtr1a1C/dashc";
   const dashcoinXLink = "https://x.com/dune_dashcoin";
 
   const [token1Address, setToken1Address] = useState("");
@@ -350,7 +349,7 @@ export default function ComparePage() {
 
   return (
     <div className="min-h-screen">
-      <Navbar dashcoinTradeLink={dashcoinTradeLink} />
+      <Navbar />
       <main className="container mx-auto px-4 py-6">
         <div className="mb-8 text-center">
           <h1 className="dashcoin-title text-4xl md:text-5xl text-dashYellow mb-4">TOKEN COMPARISON</h1>

--- a/app/creator-wallets/page.tsx
+++ b/app/creator-wallets/page.tsx
@@ -22,7 +22,7 @@ export default async function CreatorWalletsPage() {
 
   return (
     <div className="min-h-screen">
-      <Navbar dashcoinTradeLink="https://axiom.trade/meme/Fjq9SmWmtnETAVNbir1eXhrVANi1GDoHEA4nb4tNn7w6/@dashc" />
+      <Navbar />
       <main className="container mx-auto px-4 py-6 space-y-6">
         <h1 className="dashcoin-text text-3xl text-dashYellow mb-2">Creator Wallets</h1>
         <p className="mb-4 text-dashYellow-light">Track what your favorite creator is doing with their earned fees!</p>

--- a/app/env-setup.tsx
+++ b/app/env-setup.tsx
@@ -4,7 +4,6 @@ import type React from "react"
 import { useState } from "react"
 import { DashcoinButton } from "@/components/ui/dashcoin-button"
 import { DashcoinLogo } from "@/components/dashcoin-logo"
-import { ThemeToggle } from "@/components/theme-toggle"
 import {
   DashcoinCard,
   DashcoinCardHeader,
@@ -32,9 +31,6 @@ export default function EnvSetup() {
 
   return (
     <div className="flex flex-col items-center justify-center min-h-screen p-4">
-      <div className="absolute top-4 right-4">
-        <ThemeToggle />
-      </div>
 
       <div className="mb-8">
         <DashcoinLogo size={64} />

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,14 +1,11 @@
 import Link from "next/link"
 import { DashcoinButton } from "@/components/ui/dashcoin-button"
 import { DashcoinLogo } from "@/components/dashcoin-logo"
-import { ThemeToggle } from "@/components/theme-toggle"
 
 export default function NotFound() {
   return (
     <div className="flex flex-col items-center justify-center min-h-screen p-4 text-center">
-      <div className="absolute top-4 right-4">
-        <ThemeToggle />
-      </div>
+
 
       <DashcoinLogo size={64} className="mb-8" />
       <h1 className="dashcoin-title text-6xl text-dashYellow mb-4">404</h1>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -224,7 +224,6 @@ export default async function Home() {
     <div className="min-h-screen">
       {/* Use the new Navbar component */}
       <Navbar
-        dashcoinTradeLink={dashcoinTradeLink}
         dashcStats={{
           dashcoinCA,
           tradeLink: dashcoinTradeLink,

--- a/app/research/page.tsx
+++ b/app/research/page.tsx
@@ -36,7 +36,6 @@ const globalStyles = `
 `;
 
 export default function ResearchPage() {
-  const dashcoinTradeLink = "https://axiom.trade/t/fRfKGCriduzDwSudCwpL7ySCEiboNuryhZDVJtr1a1C/dashc";
   const dashcoinXLink = "https://x.com/dune_dashcoin";
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedPostId, setSelectedPostId] = useState("");
@@ -547,7 +546,7 @@ export default function ResearchPage() {
         <Hexagon size={400} />
       </div>
       
-      <Navbar dashcoinTradeLink={dashcoinTradeLink} />
+      <Navbar />
 
       <main className="p-6 relative z-10">
         {/* Upload Document Modal */}

--- a/app/token/[symbol]/page.tsx
+++ b/app/token/[symbol]/page.tsx
@@ -8,7 +8,7 @@ import {
   DashcoinCardTitle,
   DashcoinCardContent,
 } from "@/components/ui/dashcoin-card";
-import { ThemeToggle } from "@/components/theme-toggle";
+import { Navbar } from "@/components/navbar";
 import { DexscreenerChart } from "@/components/dexscreener-chart";
 import {
   fetchTokenDetails,
@@ -153,28 +153,19 @@ export default function TokenPage({ params }: { params: { symbol: string } }) {
 
   return (
     <div className="min-h-screen">
-      <header className="container mx-auto py-6 px-4">
-        <div className="flex justify-between items-center">
-          <Link href="/">
-            <DashcoinLogo size={48} />
-          </Link>
-          <div>
-            <ThemeToggle />
-          </div>
+      <Navbar />
+      <div className="mt-2 text-center">
+        <div className="flex items-center justify-center gap-1">
+          <span className="text-sm font-mono text-dashYellow-light opacity-80">
+            $DASHC CA:
+          </span>
+          <CopyAddress
+            address="7gkgsqE2Uip7LUyrqEi8fyLPNSbn7GYu9yFgtxZwYUVa"
+            showBackground={true}
+            className="text-dashYellow-light hover:text-dashYellow"
+          />
         </div>
-        <div className="mt-2 text-center">
-          <div className="flex items-center justify-center gap-1">
-            <span className="text-sm font-mono text-dashYellow-light opacity-80">
-              $DASHC CA:
-            </span>
-            <CopyAddress
-              address="7gkgsqE2Uip7LUyrqEi8fyLPNSbn7GYu9yFgtxZwYUVa"
-              showBackground={true}
-              className="text-dashYellow-light hover:text-dashYellow"
-            />
-          </div>
-        </div>
-      </header>
+      </div>
 
       <main className="container mx-auto px-4 py-6 space-y-8">
         <Link

--- a/components/founders-edge-checklist.tsx
+++ b/components/founders-edge-checklist.tsx
@@ -1,0 +1,64 @@
+import { DashcoinCard } from "@/components/ui/dashcoin-card";
+import { CheckCircle, XCircle, MinusCircle } from "lucide-react";
+import React from "react";
+
+export const canonicalChecklist = [
+  "Founder Doxxed",
+  "Dev is Active on Twitter",
+  "Successful Exit",
+  "Discussed Plans for Token Integration",
+  "Project has 200k+ views on Social Media",
+  "Live Product Exists",
+];
+
+function getIcon(value: number) {
+  switch (value) {
+    case 2:
+      return <CheckCircle className="text-green-500 w-5 h-5" />;
+    case 1:
+      return <XCircle className="text-red-500 w-5 h-5" />;
+    default:
+      return <MinusCircle className="text-yellow-400 w-5 h-5" />;
+  }
+}
+
+interface ChecklistProps {
+  data: Record<string, any>;
+  showLegend?: boolean;
+}
+
+export function FoundersEdgeChecklist({ data, showLegend = false }: ChecklistProps) {
+  if (!data) return null;
+  const score = Number(data["Score"]) || 0;
+  const borderColor =
+    score >= 70 ? "border-green-500" : score >= 40 ? "border-yellow-500" : "border-red-500";
+
+  return (
+    <DashcoinCard className={`relative bg-zinc-900 p-8 rounded-2xl shadow-lg ${borderColor}`}>\
+      <div className="absolute top-4 right-4 bg-dashYellow text-black px-3 py-1 rounded-full text-sm font-semibold shadow">
+        Score: <span className="font-bold">{score}</span> / 100
+      </div>
+      <h2 className="text-xl font-semibold text-dashYellow mb-1">Founder&apos;s Edge Checklist</h2>
+      <p className="text-sm opacity-80 mb-4">Signal-based checklist of founder credibility and product traction.</p>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+        {canonicalChecklist.map((label) => {
+          const raw = data[label];
+          const val = typeof raw === "string" ? parseInt(raw) : Number(raw);
+          return (
+            <div key={label} className="flex items-center gap-2 bg-zinc-800 rounded-full px-3 py-2">
+              {getIcon(val)}
+              <span className="text-sm">{label}</span>
+            </div>
+          );
+        })}
+      </div>
+      {showLegend && (
+        <div className="mt-4 flex items-center gap-4 text-sm">
+          <div className="flex items-center gap-1"><MinusCircle className="text-yellow-400 w-4 h-4" /> Unknown</div>
+          <div className="flex items-center gap-1"><XCircle className="text-red-500 w-4 h-4" /> No</div>
+          <div className="flex items-center gap-1"><CheckCircle className="text-green-500 w-4 h-4" /> Yes</div>
+        </div>
+      )}
+    </DashcoinCard>
+  );
+}

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -3,16 +3,13 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { DashcoinLogo } from "@/components/dashcoin-logo";
-import { ThemeToggle } from "@/components/theme-toggle";
-import { ExternalLink } from "lucide-react";
 import { DashcStatsBar, DashcStatsBarProps } from "@/components/dashc-stats-bar";
 
 interface NavbarProps {
-  dashcoinTradeLink: string;
   dashcStats?: DashcStatsBarProps;
 }
 
-export function Navbar({ dashcoinTradeLink, dashcStats }: NavbarProps) {
+export function Navbar({ dashcStats }: NavbarProps) {
   const pathname = usePathname();
 
   return (
@@ -22,22 +19,13 @@ export function Navbar({ dashcoinTradeLink, dashcStats }: NavbarProps) {
           <Link href="/">
             <DashcoinLogo size={56} />
           </Link>
-          <a
-            href={dashcoinTradeLink}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-dashYellow hover:text-dashYellow-dark font-medium dashcoin-text flex items-center text-lg"
-          >
-            SUPPORT THE PAGE <ExternalLink className="h-4 w-4 ml-1" />
-          </a>
           {dashcStats && (
             <div className="mt-4 md:mt-0 w-full md:w-auto md:ml-4">
               <DashcStatsBar {...dashcStats} />
             </div>
           )}
         </div>
-        <div className="flex items-center gap-8">
-          <ThemeToggle />
+        <div className="flex items-center gap-8 ml-auto">
           <nav className="hidden md:flex items-center gap-6">
             <NavLink href="/" active={pathname === "/"}>
               Overview
@@ -46,7 +34,7 @@ export function Navbar({ dashcoinTradeLink, dashcStats }: NavbarProps) {
               Research
             </NavLink>
             <NavLink href="/compare" active={pathname === "/compare"}>
-              Graphs & Comparisons
+              Compare Tokens
             </NavLink>
             <NavLink href="/creator-wallets" active={pathname === "/creator-wallets"}>
               Creator Wallets
@@ -64,7 +52,7 @@ export function Navbar({ dashcoinTradeLink, dashcStats }: NavbarProps) {
             Research
           </NavLink>
           <NavLink href="/compare" active={pathname === "/compare"}>
-            Graphs & Comparisons
+            Compare Tokens
           </NavLink>
           <NavLink href="/creator-wallets" active={pathname === "/creator-wallets"}>
             Creator Wallets


### PR DESCRIPTION
## Summary
- normalize research column labels when fetching from Google Sheets
- add `FoundersEdgeChecklist` component for standardized checklist display
- show checklist near token header and again with legend at bottom
- remove dark/light toggle and "Support the Page" link
- rename nav tab to "Compare Tokens" and place tabs top-right

## Testing
- `npm run lint` *(fails: next not found)*