### PR TITLE
Adjust token detail layout

### DIFF
--- a/app/token/[symbol]/page.tsx
+++ b/app/token/[symbol]/page.tsx
@@ -162,18 +162,6 @@ export default function TokenPage({ params }: { params: { symbol: string } }) {
             <ThemeToggle />
           </div>
         </div>
-        <div className="mt-2 text-center">
-          <div className="flex items-center justify-center gap-1">
-            <span className="text-sm font-mono text-dashYellow-light opacity-80">
-              $DASHC CA:
-            </span>
-            <CopyAddress
-              address="7gkgsqE2Uip7LUyrqEi8fyLPNSbn7GYu9yFgtxZwYUVa"
-              showBackground={true}
-              className="text-dashYellow-light hover:text-dashYellow"
-            />
-          </div>
-        </div>
       </header>
 
       <main className="container mx-auto px-4 py-6 space-y-8">

--- a/app/tokendetail/[symbol]/page.tsx
+++ b/app/tokendetail/[symbol]/page.tsx
@@ -248,18 +248,6 @@ export default function TokenResearchPage({
             <ThemeToggle />
           </div>
         </div>
-        <div className="mt-2 text-center">
-          <div className="flex items-center justify-center gap-1">
-            <span className="text-sm font-mono text-dashYellow-light opacity-80">
-              $DASHC CA:
-            </span>
-            <CopyAddress
-              address="7gkgsqE2Uip7LUyrqEi8fyLPNSbn7GYu9yFgtxZwYUVa"
-              showBackground={true}
-              className="text-dashYellow-light hover:text-dashYellow"
-            />
-          </div>
-        </div>
       </header>
       <main className="container mx-auto px-4 py-6 space-y-8">
         <Link
@@ -270,7 +258,7 @@ export default function TokenResearchPage({
           Back to Dashboard
         </Link>
 
-        <div className="flex flex-col md:flex-row justify-between gap-4 items-start md:items-center">
+        <div className="flex flex-col md:flex-row justify-start gap-6 items-start md:items-center">
           <div className="flex justify-between text-center">
             <div className="flex flex-col">
               <h1 className="dashcoin-title text-3xl text-dashYellow">
@@ -281,7 +269,7 @@ export default function TokenResearchPage({
           </div>
           <DashcoinCard className="md:max-w-md mt-4 md:mt-0">
             <DashcoinCardHeader>
-              <DashcoinCardTitle>Creator Wallet Activity</DashcoinCardTitle>
+              <DashcoinCardTitle className="text-2xl">Creator Wallet Activity</DashcoinCardTitle>
             </DashcoinCardHeader>
             <DashcoinCardContent>
               <p>{researchData?.["Wallet Comments"] || "No wallet activity available"}</p>
@@ -297,6 +285,17 @@ export default function TokenResearchPage({
               ) : null}
             </DashcoinCardContent>
           </DashcoinCard>
+          {researchData?.Twitter && (
+            <a
+              href={`${researchData.Twitter.replace("@", "")}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="bg-[#1DA1F2] hover:bg-[#1a91da] text-white px-4 py-2 rounded-md flex items-center transition-colors"
+            >
+              <Twitter className="h-4 w-4 mr-2" />
+              View on Twitter
+            </a>
+          )}
           <div className="flex gap-2">
             <a
               href={
@@ -305,7 +304,7 @@ export default function TokenResearchPage({
               }
               target="_blank"
               rel="noopener noreferrer"
-              className="text-dashYellow hover:text-dashYellow-dark font-medium dashcoin-text flex items-center"
+              className="text-dashYellow hover:text-dashYellow-dark font-medium dashcoin-text flex items-center px-4 py-2 text-lg"
             >
               Trade
               <ExternalLink className="h-4 w-4 ml-1" />
@@ -446,21 +445,7 @@ export default function TokenResearchPage({
           </p>
         </DashcoinCard>
       ) : (
-        <div className="space-y-8">
-          {researchData?.Twitter && (
-            <div className="flex justify-end">
-              <a
-                href={`${researchData.Twitter.replace("@", "")}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="bg-[#1DA1F2] hover:bg-[#1a91da] text-white px-4 py-2 rounded-md flex items-center transition-colors"
-              >
-                <Twitter className="h-4 w-4 mr-2" />
-                View on Twitter
-              </a>
-            </div>
-          )}
-        </div>
+        <div className="space-y-8"></div>
       )}
 
       <footer className="container mx-auto py-8 px-4 mt-12 border-t border-dashGreen-light">

--- a/components/founders-edge-checklist.tsx
+++ b/components/founders-edge-checklist.tsx
@@ -34,20 +34,30 @@ export function FoundersEdgeChecklist({ data, showLegend = false }: ChecklistPro
     score >= 70 ? "border-green-500" : score >= 40 ? "border-yellow-500" : "border-red-500";
 
   return (
-    <DashcoinCard className={`relative bg-zinc-900 p-8 rounded-2xl shadow-lg ${borderColor}`}>
-      <div className="absolute top-4 right-4 bg-dashYellow text-black px-3 py-1 rounded-full text-sm font-semibold shadow">
-        Score: <span className="font-bold">{score}</span> / 100
+    <DashcoinCard
+      className={`relative bg-zinc-900 p-10 rounded-2xl shadow-lg ${borderColor}`}
+    >
+      <div className="flex justify-center items-center gap-6 mb-4">
+        <h2 className="text-2xl font-semibold text-dashYellow">Founder&apos;s Edge Checklist</h2>
+        <div className="bg-dashYellow text-black px-3 py-1 rounded-full text-sm font-semibold shadow flex items-center">
+          <span>
+            Score: <span className="font-bold">{score}</span> / 100
+          </span>
+          {score >= 75 && <span className="ml-2 animate-bounce">🐸</span>}
+        </div>
       </div>
-      <h2 className="text-xl font-semibold text-dashYellow mb-1">Founder&apos;s Edge Checklist</h2>
-      <p className="text-sm opacity-80 mb-4">Signal-based checklist of founder credibility and product traction.</p>
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+      <p className="text-base opacity-80 mb-6 text-center">Signal-based checklist of founder credibility and product traction.</p>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
         {canonicalChecklist.map((label) => {
           const raw = data[label];
           const val = typeof raw === "string" ? parseInt(raw) : Number(raw);
           return (
-            <div key={label} className="flex items-center gap-2 bg-zinc-800 rounded-full px-3 py-2">
+            <div
+              key={label}
+              className="flex items-center gap-2 bg-zinc-800 rounded-full px-4 py-3"
+            >
               {getIcon(val)}
-              <span className="text-sm">{label}</span>
+              <span className="text-base">{label}</span>
             </div>
           );
         })}


### PR DESCRIPTION
## Summary
- enlarge Founder's Edge Checklist card and typography
- remove Dashcoin contract address from token pages
- move View on Twitter near Creator Wallet Activity
- bump Creator Wallet Activity title size
- reposition trade button and increase its size
- show Score badge next to Founder's Edge header and add celebratory frog when score >=75

## Testing
- `npm run lint` *(fails: `next` not found)*