### PR TITLE
Move charts above token table

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -238,6 +238,28 @@ export default async function Home() {
 
       <main className="container mx-auto px-4 py-6 space-y-6">
 
+        {/* Charts */}
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mt-4">
+          <Suspense
+            fallback={
+              <DashcoinCard className="h-80 flex items-center justify-center">
+                <p>Loading chart...</p>
+              </DashcoinCard>
+            }
+          >
+            <MarketCapChartWrapper marketCapTimeDataPromise={marketCapTimeDataPromise} />
+          </Suspense>
+          <Suspense
+            fallback={
+              <DashcoinCard className="h-80 flex items-center justify-center">
+                <p>Loading chart...</p>
+              </DashcoinCard>
+            }
+          >
+            <MarketCapPieWrapper tokenMarketCapsPromise={tokenMarketCapsPromise} />
+          </Suspense>
+        </div>
+
         {/* Token Table */}
         <div className="mt-4">
           <h2 className="dashcoin-text text-3xl text-dashYellow mb-4">
@@ -337,29 +359,6 @@ export default async function Home() {
           </DashcoinCard>
         </div>
 
-        {/* Charts */}
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mt-8">
-          <Suspense
-            fallback={
-              <DashcoinCard className="h-80 flex items-center justify-center">
-                <p>Loading chart...</p>
-              </DashcoinCard>
-            }
-          >
-            <MarketCapChartWrapper marketCapTimeDataPromise={marketCapTimeDataPromise} />
-          </Suspense>
-          <Suspense
-            fallback={
-              <DashcoinCard className="h-80 flex items-center justify-center">
-                <p>Loading chart...</p>
-              </DashcoinCard>
-            }
-          >
-            <MarketCapPieWrapper tokenMarketCapsPromise={tokenMarketCapsPromise} />
-          </Suspense>
-        </div>
-
-        
       </main>
 
       <footer className="container mx-auto py-8 px-4 mt-12 border-t border-dashGreen-light">


### PR DESCRIPTION
## Summary
- move overview page charts to top of page, ahead of the token table

## Testing
- `./setup.sh` *(fails: npm install requires network)*
- `npm run lint` *(fails: `next` not found)*