### PR TITLE
Move charts above token table

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -37,7 +37,7 @@ const MarketCapChartWrapper = async ({
   } catch (error) {
     console.error("Error in MarketCapChartWrapper:", error);
     return (
-      <DashcoinCard className="h-80 flex items-center justify-center">
+      <DashcoinCard className="h-48 flex items-center justify-center">
         <p>Error loading chart data</p>
       </DashcoinCard>
     );
@@ -55,7 +55,7 @@ const MarketCapPieWrapper = async ({
   } catch (error) {
     console.error("Error in MarketCapPieWrapper:", error);
     return (
-      <DashcoinCard className="h-80 flex items-center justify-center">
+      <DashcoinCard className="h-48 flex items-center justify-center">
         <p>Error loading chart data</p>
       </DashcoinCard>
     );
@@ -236,7 +236,29 @@ export default async function Home() {
         }}
       />
 
-      <main className="container mx-auto px-4 py-6 space-y-6">
+      <main className="container mx-auto px-4 py-4 space-y-6">
+
+        {/* Charts */}
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mt-0">
+          <Suspense
+            fallback={
+              <DashcoinCard className="h-48 flex items-center justify-center">
+                <p>Loading chart...</p>
+              </DashcoinCard>
+            }
+          >
+            <MarketCapChartWrapper marketCapTimeDataPromise={marketCapTimeDataPromise} />
+          </Suspense>
+          <Suspense
+            fallback={
+              <DashcoinCard className="h-48 flex items-center justify-center">
+                <p>Loading chart...</p>
+              </DashcoinCard>
+            }
+          >
+            <MarketCapPieWrapper tokenMarketCapsPromise={tokenMarketCapsPromise} />
+          </Suspense>
+        </div>
 
         {/* Token Table */}
         <div className="mt-4">
@@ -337,29 +359,6 @@ export default async function Home() {
           </DashcoinCard>
         </div>
 
-        {/* Charts */}
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mt-8">
-          <Suspense
-            fallback={
-              <DashcoinCard className="h-80 flex items-center justify-center">
-                <p>Loading chart...</p>
-              </DashcoinCard>
-            }
-          >
-            <MarketCapChartWrapper marketCapTimeDataPromise={marketCapTimeDataPromise} />
-          </Suspense>
-          <Suspense
-            fallback={
-              <DashcoinCard className="h-80 flex items-center justify-center">
-                <p>Loading chart...</p>
-              </DashcoinCard>
-            }
-          >
-            <MarketCapPieWrapper tokenMarketCapsPromise={tokenMarketCapsPromise} />
-          </Suspense>
-        </div>
-
-        
       </main>
 
       <footer className="container mx-auto py-8 px-4 mt-12 border-t border-dashGreen-light">

--- a/components/market-cap-chart.tsx
+++ b/components/market-cap-chart.tsx
@@ -151,7 +151,7 @@ export function MarketCapChart({ data }: MarketCapChartProps) {
         <DashcoinCardTitle>Market Cap & Holders Over Time</DashcoinCardTitle>
       </DashcoinCardHeader>
       <DashcoinCardContent>
-        <div className="h-80 bg-[#13131A]">
+        <div className="h-48 bg-[#13131A]">
           <canvas ref={chartRef} />
         </div>
         <DuneQueryLink queryId={5119241} className="mt-2" />

--- a/components/market-cap-pie.tsx
+++ b/components/market-cap-pie.tsx
@@ -121,7 +121,7 @@ export function MarketCapPie({ data }: MarketCapPieProps) {
         <DashcoinCardTitle>Market Cap Distribution</DashcoinCardTitle>
       </DashcoinCardHeader>
       <DashcoinCardContent>
-        <div className="h-80 bg-[#13131A]">
+        <div className="h-48 bg-[#13131A]">
           <canvas ref={chartRef} />
         </div>
         <DuneQueryLink queryId={5140151} className="mt-2" />


### PR DESCRIPTION
## Summary
- move overview page charts to top of page, ahead of the token table
- shrink chart height by about 40%
- reduce spacing between nav bar and charts for tighter layout

## Testing
- `./setup.sh` *(fails: npm install requires network)*
- `npm run lint` *(fails: `next` not found)*