### PR TITLE
Remove support link and simplify stats bar

### DIFF
--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -92,7 +92,6 @@ const CustomTooltip = ({ active, payload, label }: any) => {
 };
 
 export default function ComparePage() {
-  const dashcoinTradeLink = "https://axiom.trade/t/fRfKGCriduzDwSudCwpL7ySCEiboNuryhZDVJtr1a1C/dashc";
   const dashcoinXLink = "https://x.com/dune_dashcoin";
 
   const [token1Address, setToken1Address] = useState("");
@@ -350,7 +349,7 @@ export default function ComparePage() {
 
   return (
     <div className="min-h-screen">
-      <Navbar dashcoinTradeLink={dashcoinTradeLink} />
+      <Navbar />
       <main className="container mx-auto px-4 py-6">
         <div className="mb-8 text-center">
           <h1 className="dashcoin-title text-4xl md:text-5xl text-dashYellow mb-4">TOKEN COMPARISON</h1>

--- a/app/creator-wallets/page.tsx
+++ b/app/creator-wallets/page.tsx
@@ -22,7 +22,7 @@ export default async function CreatorWalletsPage() {
 
   return (
     <div className="min-h-screen">
-      <Navbar dashcoinTradeLink="https://axiom.trade/meme/Fjq9SmWmtnETAVNbir1eXhrVANi1GDoHEA4nb4tNn7w6/@dashc" />
+      <Navbar />
       <main className="container mx-auto px-4 py-6 space-y-6">
         <h1 className="dashcoin-text text-3xl text-dashYellow mb-2">Creator Wallets</h1>
         <p className="mb-4 text-dashYellow-light">Track what your favorite creator is doing with their earned fees!</p>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -224,15 +224,9 @@ export default async function Home() {
     <div className="min-h-screen">
       {/* Use the new Navbar component */}
       <Navbar
-        dashcoinTradeLink={dashcoinTradeLink}
         dashcStats={{
-          dashcoinCA,
           tradeLink: dashcoinTradeLink,
-          price: dashcPrice,
           marketCap: dashcMarketCap,
-          volume: dashcVolume,
-          change24h: dashcChange24h,
-          liquidity: dashcLiquidity,
         }}
       />
 

--- a/app/research/page.enabled.tsx
+++ b/app/research/page.enabled.tsx
@@ -36,7 +36,6 @@ const globalStyles = `
 `;
 
 export default function ResearchPage() {
-  const dashcoinTradeLink = "https://axiom.trade/t/fRfKGCriduzDwSudCwpL7ySCEiboNuryhZDVJtr1a1C/dashc";
   const dashcoinXLink = "https://x.com/dune_dashcoin";
   const [searchQuery, setSearchQuery] = useState("");
   const [selectedPostId, setSelectedPostId] = useState("");
@@ -547,7 +546,7 @@ export default function ResearchPage() {
         <Hexagon size={400} />
       </div>
       
-      <Navbar dashcoinTradeLink={dashcoinTradeLink} />
+      <Navbar />
 
       <main className="p-6 relative z-10">
         {/* Upload Document Modal */}

--- a/components/dashc-stats-bar.tsx
+++ b/components/dashc-stats-bar.tsx
@@ -1,56 +1,20 @@
 import { formatCurrency } from "@/lib/utils";
-import { CopyAddress } from "@/components/copy-address";
 
 interface DashcStatsBarProps {
-  dashcoinCA: string;
   tradeLink: string;
-  price: number;
   marketCap: number;
-  volume: number;
-  change24h: number;
-  liquidity: number;
 }
 
-export function DashcStatsBar({
-  dashcoinCA,
-  tradeLink,
-  price,
-  marketCap,
-  volume,
-  change24h,
-  liquidity,
-}: DashcStatsBarProps) {
+export function DashcStatsBar({ tradeLink, marketCap }: DashcStatsBarProps) {
   return (
-    <div className="flex flex-wrap justify-between items-center gap-2 bg-dashGreen-dark rounded-lg border border-dashBlack py-2 px-4 w-full md:w-auto">
-      <div className="flex items-center gap-2">
-        <span className="font-medium text-dashYellow text-sm">$DASHC:</span>
-        <CopyAddress
-          address={dashcoinCA}
-          truncate
-          displayLength={6}
-          className="text-dashYellow-light hover:text-dashYellow text-sm"
-        />
+    <div className="flex flex-wrap justify-between items-center gap-1 bg-dashGreen-dark rounded-lg border border-dashBlack py-1 px-2 w-full md:w-auto text-xs">
+      <div className="flex items-center gap-1">
+        <span className="font-medium text-dashYellow">$DASHC</span>
       </div>
-      <div className="flex flex-wrap gap-4 justify-center">
+      <div className="flex flex-wrap gap-2 justify-center">
         <div className="text-center">
-          <span className="text-xs opacity-70 font-medium">Price</span>
-          <p className="text-sm font-medium">${price.toFixed(price < 0.01 ? 8 : 6)}</p>
-        </div>
-        <div className="text-center">
-          <span className="text-xs opacity-70 font-medium">Market Cap</span>
-          <p className="text-sm font-medium">{formatCurrency(marketCap)}</p>
-        </div>
-        <div className="text-center">
-          <span className="text-xs opacity-70 font-medium">24h Volume</span>
-          <p className="text-sm font-medium">{formatCurrency(volume)}</p>
-        </div>
-        <div className="text-center">
-          <span className="text-xs opacity-70 font-medium">24h Change</span>
-          <p className={`text-sm font-medium ${change24h >= 0 ? "text-dashGreen-accent" : "text-dashRed"}`}>{change24h >= 0 ? "+" : ""}{change24h.toFixed(2)}%</p>
-        </div>
-        <div className="text-center">
-          <span className="text-xs opacity-70 font-medium">Liquidity</span>
-          <p className="text-sm font-medium">{formatCurrency(liquidity)}</p>
+          <span className="opacity-70 font-medium">Market Cap</span>
+          <p className="font-medium">{formatCurrency(marketCap)}</p>
         </div>
       </div>
       <div>
@@ -58,7 +22,7 @@ export function DashcStatsBar({
           href={tradeLink}
           target="_blank"
           rel="noopener noreferrer"
-          className="px-3 py-1 bg-dashYellow text-dashBlack font-medium rounded-md hover:bg-dashYellow-dark transition-colors text-sm flex items-center justify-center border border-dashBlack"
+          className="px-2 py-0.5 bg-dashYellow text-dashBlack font-medium rounded-md hover:bg-dashYellow-dark transition-colors flex items-center justify-center border border-dashBlack"
         >
           TRADE
         </a>

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -3,15 +3,13 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { DashcoinLogo } from "@/components/dashcoin-logo";
-import { ExternalLink } from "lucide-react";
 import { DashcStatsBar, DashcStatsBarProps } from "@/components/dashc-stats-bar";
 
 interface NavbarProps {
-  dashcoinTradeLink: string;
   dashcStats?: DashcStatsBarProps;
 }
 
-export function Navbar({ dashcoinTradeLink, dashcStats }: NavbarProps) {
+export function Navbar({ dashcStats }: NavbarProps) {
   const pathname = usePathname();
 
   return (
@@ -21,14 +19,6 @@ export function Navbar({ dashcoinTradeLink, dashcStats }: NavbarProps) {
           <Link href="/">
             <DashcoinLogo size={56} />
           </Link>
-          <a
-            href={dashcoinTradeLink}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-dashYellow hover:text-dashYellow-dark font-medium dashcoin-text flex items-center text-lg"
-          >
-            SUPPORT THE PAGE <ExternalLink className="h-4 w-4 ml-1" />
-          </a>
           {dashcStats && (
             <div className="mt-4 md:mt-0 w-full md:w-auto md:ml-4">
               <DashcStatsBar {...dashcStats} />


### PR DESCRIPTION
## Summary
- trim Navbar component and drop "Support the page" link
- shrink DashcStatsBar to only show name, market cap and TRADE button
- update pages to use simplified Navbar and stats bar

## Testing
- `npm run lint` *(fails: next not found)*