### PR TITLE
Expand Google Sheet research range

### DIFF
--- a/app/actions/googlesheet-action.ts
+++ b/app/actions/googlesheet-action.ts
@@ -8,7 +8,7 @@ export async function fetchTokenResearch(): Promise<ResearchScoreData[]> {
   const API_KEY = 'AIzaSyC8QxJez_UTHUJS7vFj1J3Sje0CWS9tXyk';
   const SHEET_ID = '1Nra5QH-JFAsDaTYSyu-KocjbkZ0MATzJ4R-rUt-gLe0';
   const SHEET_NAME = 'Dashcoin Scoring';
-  const RANGE = `${SHEET_NAME}!A1:M30`;
+  const RANGE = `${SHEET_NAME}!A1:M100`;
   const url = `https://sheets.googleapis.com/v4/spreadsheets/${SHEET_ID}/values/${RANGE}?key=${API_KEY}`;
 
   try {
@@ -72,7 +72,7 @@ export async function fetchCreatorWalletLinks(): Promise<WalletLinkData[]> {
   const API_KEY = 'AIzaSyC8QxJez_UTHUJS7vFj1J3Sje0CWS9tXyk'
   const SHEET_ID = '1Nra5QH-JFAsDaTYSyu-KocjbkZ0MATzJ4R-rUt-gLe0'
   const SHEET_NAME = 'Dashcoin Scoring'
-  const RANGE = `${SHEET_NAME}!A1:M30`
+  const RANGE = `${SHEET_NAME}!A1:M100`
   const url = `https://sheets.googleapis.com/v4/spreadsheets/${SHEET_ID}/values/${RANGE}?key=${API_KEY}`
 
   try {

--- a/app/tokendetail/[symbol]/page.tsx
+++ b/app/tokendetail/[symbol]/page.tsx
@@ -50,7 +50,7 @@ async function fetchTokenResearch(
   const API_KEY = "AIzaSyC8QxJez_UTHUJS7vFj1J3Sje0CWS9tXyk";
   const SHEET_ID = "1Nra5QH-JFAsDaTYSyu-KocjbkZ0MATzJ4R-rUt-gLe0";
   const SHEET_NAME = "Dashcoin Scoring";
-  const RANGE = `${SHEET_NAME}!A1:M30`;
+  const RANGE = `${SHEET_NAME}!A1:M100`;
   const url = `https://sheets.googleapis.com/v4/spreadsheets/${SHEET_ID}/values/${RANGE}?key=${API_KEY}`;
 
   try {


### PR DESCRIPTION
## Summary
- pull the first 100 rows from the Google Sheet when fetching token research
- update the token details page to use the same range

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6839f7f33748832cb0488460f3933941