### PR TITLE
Remove Dune query links

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -22,7 +22,6 @@ import { formatCurrency } from "@/lib/utils";
 import EnvSetup from "./env-setup";
 import { Suspense } from "react";
 import TokenTable from "@/components/token-table";
-import { DuneQueryLink } from "@/components/dune-query-link";
 import { Navbar } from "@/components/navbar";
 import { Twitter } from "lucide-react";
 
@@ -287,7 +286,6 @@ export default async function Home() {
                   ? new Date(totalMarketCap.latest_data_at).toLocaleString()
                   : "N/A"}
               </p>
-              <DuneQueryLink queryId={5140151} className="mt-2 justify-center" />
             </DashcoinCardContent>
           </DashcoinCard>
 
@@ -298,7 +296,6 @@ export default async function Home() {
             <DashcoinCardContent className="text-center">
               <p className="dashcoin-text text-4xl text-dashYellow">{formattedCoinLaunches}</p>
               <p className="text-sm opacity-80 mt-2">Total coins tracked</p>
-              <DuneQueryLink queryId={5140151} className="mt-2 justify-center" />
             </DashcoinCardContent>
           </DashcoinCard>
         </div>
@@ -320,7 +317,6 @@ export default async function Home() {
                 hoursRemaining={hoursUntilRefresh}
                 minutesRemaining={minutesUntilRefresh}
               />
-              <DuneQueryLink queryId={5140151} className="mt-2" />
             </DashcoinCardContent>
           </DashcoinCard>
 
@@ -333,7 +329,6 @@ export default async function Home() {
               <div className="mt-2 pt-2 border-t border-dashGreen-light opacity-50">
                 <p className="text-sm">From Dune Analytics</p>
               </div>
-              <DuneQueryLink queryId={5140151} className="mt-2" />
             </DashcoinCardContent>
           </DashcoinCard>
 
@@ -348,7 +343,6 @@ export default async function Home() {
               <div className="mt-2 pt-2 border-t border-dashGreen-light opacity-50">
                 <p className="text-sm">Estimated at 0.3% of volume</p>
               </div>
-              <DuneQueryLink queryId={5140151} className="mt-2" />
             </DashcoinCardContent>
           </DashcoinCard>
         </div>

--- a/components/market-cap-chart.tsx
+++ b/components/market-cap-chart.tsx
@@ -4,7 +4,6 @@ import { useEffect, useRef } from "react"
 import { DashcoinCard, DashcoinCardHeader, DashcoinCardTitle, DashcoinCardContent } from "@/components/ui/dashcoin-card"
 import type { MarketCapTimeData } from "@/types/dune"
 import { formatCurrency, getCssVariable, hexToRgba } from "@/lib/utils"
-import { DuneQueryLink } from "@/components/dune-query-link"
 
 declare global {
   interface Window {
@@ -154,7 +153,6 @@ export function MarketCapChart({ data }: MarketCapChartProps) {
         <div className="h-48 bg-[#13131A]">
           <canvas ref={chartRef} />
         </div>
-        <DuneQueryLink queryId={5119241} className="mt-2" />
       </DashcoinCardContent>
     </DashcoinCard>
   )

--- a/components/market-cap-pie.tsx
+++ b/components/market-cap-pie.tsx
@@ -4,7 +4,6 @@ import { useEffect, useRef } from "react"
 import { DashcoinCard, DashcoinCardHeader, DashcoinCardTitle, DashcoinCardContent } from "@/components/ui/dashcoin-card"
 import type { TokenMarketCapData } from "@/types/dune"
 import { formatCurrency, getCssVariable, hexToRgba } from "@/lib/utils"
-import { DuneQueryLink } from "@/components/dune-query-link"
 
 interface MarketCapPieProps {
   data: TokenMarketCapData[]
@@ -124,7 +123,6 @@ export function MarketCapPie({ data }: MarketCapPieProps) {
         <div className="h-48 bg-[#13131A]">
           <canvas ref={chartRef} />
         </div>
-        <DuneQueryLink queryId={5140151} className="mt-2" />
       </DashcoinCardContent>
     </DashcoinCard>
   )

--- a/components/new-tokens-table.tsx
+++ b/components/new-tokens-table.tsx
@@ -3,7 +3,6 @@ import { DashcoinCard, DashcoinCardHeader, DashcoinCardTitle, DashcoinCardConten
 import type { NewTokenData } from "@/types/dune"
 import { formatCurrency } from "@/lib/utils"
 import { CopyAddress } from "@/components/copy-address"
-import { DuneQueryLink } from "@/components/dune-query-link"
 
 interface NewTokensTableProps {
   data: NewTokenData[]
@@ -78,9 +77,6 @@ export function NewTokensTable({ data }: NewTokensTableProps) {
               )}
             </tbody>
           </table>
-        </div>
-        <div className="flex justify-end mt-4">
-          <DuneQueryLink queryId={5140151} />
         </div>
       </DashcoinCardContent>
     </DashcoinCard>

--- a/components/token-table.tsx
+++ b/components/token-table.tsx
@@ -8,7 +8,6 @@ import { ChevronDown, ChevronUp, Search, Loader2, FileSearch, Filter } from "luc
 import { fetchPaginatedTokens } from "@/app/actions/dune-actions"
 import type { TokenData, PaginatedTokenResponse } from "@/types/dune"
 import { CopyAddress } from "@/components/copy-address"
-import { DuneQueryLink } from "@/components/dune-query-link"
 import { batchFetchTokensData } from "@/app/actions/dexscreener-actions"
 import { useCallback } from "react"
 import { fetchTokenResearch } from "@/app/actions/googlesheet-action"
@@ -557,13 +556,11 @@ export default function TokenTable({ data }: { data: PaginatedTokenResponse | To
         </div>
       </DashcoinCard>
 
-      {/* Dune Query Link */}
       <div className="flex justify-between mt-2">
         <div className="text-xs opacity-70 mt-1">
           Last updated: {lastRefreshed ? lastRefreshed.toLocaleTimeString() : 'Never'} 
           {lastRefreshed && <span> (refreshing in {refreshCountdown}s)</span>}
         </div>
-        <DuneQueryLink queryId={5140151} />
       </div>
 
       {/* Pagination - Fixed using handlePageChange */}


### PR DESCRIPTION
## Summary
- scrub all Dune query links that showed `Dune Query #<id>` at the bottom of several charts
- drop the unused comment in `token-table`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a01ec2110832cab27500df2e3b5a3