### PR TITLE
Fix market stats layout on home page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -273,22 +273,7 @@ export default async function Home() {
         </div>
 
         {/* Summary Stats */}
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
-          <DashcoinCard className="flex flex-col items-center justify-center py-8">
-            <DashcoinCardHeader>
-              <DashcoinCardTitle>Total Market Cap</DashcoinCardTitle>
-            </DashcoinCardHeader>
-            <DashcoinCardContent className="text-center">
-              <p className="dashcoin-text text-4xl text-dashYellow">{formattedMarketCap}</p>
-              <p className="text-sm opacity-80 mt-2">
-                Last updated:{" "}
-                {totalMarketCap && totalMarketCap.latest_data_at
-                  ? new Date(totalMarketCap.latest_data_at).toLocaleString()
-                  : "N/A"}
-              </p>
-            </DashcoinCardContent>
-          </DashcoinCard>
-
+        <div className="grid grid-cols-1 gap-6 mb-8">
           <DashcoinCard className="flex flex-col items-center justify-center py-8">
             <DashcoinCardHeader>
               <DashcoinCardTitle>Coin Launches</DashcoinCardTitle>
@@ -301,10 +286,10 @@ export default async function Home() {
         </div>
 
         {/* Market Stats */}
-        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <DashcoinCard>
             <DashcoinCardHeader>
-              <DashcoinCardTitle>Market Cap</DashcoinCardTitle>
+              <DashcoinCardTitle>Total Market Cap of Believe Coins excl. Launchcoin</DashcoinCardTitle>
             </DashcoinCardHeader>
             <DashcoinCardContent>
               <p className="dashcoin-text text-3xl text-dashYellow">{formattedMarketCap}</p>
@@ -322,19 +307,7 @@ export default async function Home() {
 
           <DashcoinCard>
             <DashcoinCardHeader>
-              <DashcoinCardTitle>24h Volume</DashcoinCardTitle>
-            </DashcoinCardHeader>
-            <DashcoinCardContent>
-              <p className="dashcoin-text text-3xl text-dashYellow">{formattedVolume}</p>
-              <div className="mt-2 pt-2 border-t border-dashGreen-light opacity-50">
-                <p className="text-sm">From Dune Analytics</p>
-              </div>
-            </DashcoinCardContent>
-          </DashcoinCard>
-
-          <DashcoinCard>
-            <DashcoinCardHeader>
-              <DashcoinCardTitle>Fee Earnings</DashcoinCardTitle>
+              <DashcoinCardTitle>Total Creator Fees</DashcoinCardTitle>
             </DashcoinCardHeader>
             <DashcoinCardContent>
               <p className="dashcoin-text text-3xl text-dashYellow">


### PR DESCRIPTION
## Summary
- remove duplicate total market cap card
- show only coin launches in summary
- make market stats show just total market cap and creator fee cards
- rename `Fee Earnings` to `Total Creator Fees`
- rename market cap card

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a2151d0bc832c82c8ac1039bd6e82