### PR TITLE
fix: expand sheet range to restore creator-wallets

### DIFF
--- a/__tests__/creatorWallet.test.ts
+++ b/__tests__/creatorWallet.test.ts
@@ -1,0 +1,13 @@
+import { strict as assert } from 'node:assert';
+import { parseRow } from '../src/lib/sheets';
+
+const sampleRow = [] as any[];
+sampleRow[12] = '0xABC';
+sampleRow[13] = 'founder.eth';
+sampleRow[14] = 'some comment';
+
+const project = parseRow(sampleRow);
+
+assert.equal(project.creatorWallet, '0xABC');
+assert.equal(project.creatorENS, 'founder.eth');
+assert.equal(project.walletComment, 'some comment');

--- a/app/actions/googlesheet-action.ts
+++ b/app/actions/googlesheet-action.ts
@@ -8,7 +8,7 @@ export async function fetchTokenResearch(): Promise<ResearchScoreData[]> {
   const API_KEY = 'AIzaSyC8QxJez_UTHUJS7vFj1J3Sje0CWS9tXyk';
   const SHEET_ID = '1Nra5QH-JFAsDaTYSyu-KocjbkZ0MATzJ4R-rUt-gLe0';
   const SHEET_NAME = 'Dashcoin Scoring';
-  const RANGE = `${SHEET_NAME}!A1:M100`;
+  const RANGE = `${SHEET_NAME}!A1:O100`;
   const url = `https://sheets.googleapis.com/v4/spreadsheets/${SHEET_ID}/values/${RANGE}?key=${API_KEY}`;
 
   try {
@@ -72,7 +72,7 @@ export async function fetchCreatorWalletLinks(): Promise<WalletLinkData[]> {
   const API_KEY = 'AIzaSyC8QxJez_UTHUJS7vFj1J3Sje0CWS9tXyk'
   const SHEET_ID = '1Nra5QH-JFAsDaTYSyu-KocjbkZ0MATzJ4R-rUt-gLe0'
   const SHEET_NAME = 'Dashcoin Scoring'
-  const RANGE = `${SHEET_NAME}!A1:M100`
+  const RANGE = `${SHEET_NAME}!A1:O100`
   const url = `https://sheets.googleapis.com/v4/spreadsheets/${SHEET_ID}/values/${RANGE}?key=${API_KEY}`
 
   try {

--- a/app/tokendetail/[symbol]/page.tsx
+++ b/app/tokendetail/[symbol]/page.tsx
@@ -50,7 +50,7 @@ async function fetchTokenResearch(
   const API_KEY = "AIzaSyC8QxJez_UTHUJS7vFj1J3Sje0CWS9tXyk";
   const SHEET_ID = "1Nra5QH-JFAsDaTYSyu-KocjbkZ0MATzJ4R-rUt-gLe0";
   const SHEET_NAME = "Dashcoin Scoring";
-  const RANGE = `${SHEET_NAME}!A1:M100`;
+  const RANGE = `${SHEET_NAME}!A1:O100`;
   const url = `https://sheets.googleapis.com/v4/spreadsheets/${SHEET_ID}/values/${RANGE}?key=${API_KEY}`;
 
   try {

--- a/components/CreatorWalletCard.tsx
+++ b/components/CreatorWalletCard.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { DashcoinCard, DashcoinCardHeader, DashcoinCardTitle, DashcoinCardContent } from "@/components/ui/dashcoin-card";
+import { CopyAddress } from "@/components/copy-address";
+import { Badge } from "@/components/ui/badge";
+
+interface CreatorWalletCardProps {
+  creatorWallet: string | null;
+  creatorENS: string | null;
+  walletComment: string | null;
+}
+
+export function CreatorWalletCard({ creatorWallet, creatorENS, walletComment }: CreatorWalletCardProps) {
+  return (
+    <DashcoinCard>
+      <DashcoinCardHeader>
+        <DashcoinCardTitle>Creator Wallet</DashcoinCardTitle>
+      </DashcoinCardHeader>
+      <DashcoinCardContent>
+        <div className="space-y-2">
+          {creatorWallet ? (
+            <CopyAddress address={creatorWallet} />
+          ) : (
+            <p className="opacity-60">No wallet available</p>
+          )}
+          {creatorENS && <Badge variant="outline">{creatorENS}</Badge>}
+          <p>{walletComment ? walletComment : "No comment yet"}</p>
+        </div>
+      </DashcoinCardContent>
+    </DashcoinCard>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "node --test"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",

--- a/src/lib/sheets.ts
+++ b/src/lib/sheets.ts
@@ -1,0 +1,19 @@
+import type { Project } from "../types/Project";
+
+export const range = "Dashcoin!A2:O"; // TODO: If columns grow, switch to header-driven parsing.
+
+export function parseRow(row: any[]): Project {
+  return {
+    creatorWallet: row[12] ?? null,
+    creatorENS: row[13] ?? null,
+    walletComment: row[14] ?? null,
+  };
+}
+
+export async function fetchSheetData(sheetId: string, apiKey: string): Promise<Project[]> {
+  const url = `https://sheets.googleapis.com/v4/spreadsheets/${sheetId}/values/${range}?key=${apiKey}`;
+  const res = await fetch(url);
+  const data = await res.json();
+  const rows: any[][] = data.values || [];
+  return rows.map(parseRow);
+}

--- a/src/types/Project.ts
+++ b/src/types/Project.ts
@@ -1,0 +1,5 @@
+export interface Project {
+  creatorWallet: string | null;
+  creatorENS: string | null;
+  walletComment: string | null;
+}


### PR DESCRIPTION
## Summary
- fetch wallet columns through `O` to include creator wallets
- add project types and new creator wallet card component
- provide helper to read wallet columns
- add basic unit test scaffold and `test` script

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_683a90fc6f3c832cb75536848159eeb3