### PR TITLE
feat: founders-guide tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The cache admin interface is available at `/admin/cache`. This interface allows 
 - `KV_REST_API_TOKEN`: Your Upstash Redis API token
 - `ENABLE_DUNE_API`: Set to `true` to enable real Dune API calls (default: `false`)
 - `VERCEL_ENV`: Automatically set by Vercel to indicate the environment
+- `NEXT_PUBLIC_FOUNDERS_GUIDE_DOC_URL`: Public URL for the Founders Guide Google Document (defaults to our live doc if unset)
 
 ## Cache Keys
 

--- a/app/founders-guide/page.tsx
+++ b/app/founders-guide/page.tsx
@@ -1,0 +1,35 @@
+import { Navbar } from "@/components/navbar";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Founders Guide | Dashcoin Research",
+};
+
+const GUIDE_URL =
+  process.env.NEXT_PUBLIC_FOUNDERS_GUIDE_DOC_URL ||
+  "https://docs.google.com/document/d/1fZHrmJOpcOIDzgYCkrqJk0yp8LM9kYXRISdChOthPv8/preview";
+
+export default function FoundersGuidePage() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar />
+      <main className="container mx-auto px-4 py-6 flex-1 flex flex-col gap-6">
+        <h1 className="dashcoin-text text-3xl text-dashYellow mb-2">Founders Guide</h1>
+        <div className="flex-1 min-h-[60vh] bg-white rounded-md overflow-hidden shadow">
+          {GUIDE_URL ? (
+            <iframe
+              src={GUIDE_URL}
+              title="Founders Guide"
+              className="w-full h-full border-0"
+            />
+          ) : (
+            <p className="dashcoin-text text-dashYellow-light">
+              Guide URL not configured.
+            </p>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+}
+

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -36,6 +36,9 @@ export function Navbar({ dashcStats }: NavbarProps) {
             <NavLink href="/creator-wallets" active={pathname === "/creator-wallets"}>
               Creator Wallets
             </NavLink>
+            <NavLink href="/founders-guide" active={pathname === "/founders-guide"}>
+              Founders Guide
+            </NavLink>
           </nav>
         </div>
       </div>
@@ -50,6 +53,9 @@ export function Navbar({ dashcStats }: NavbarProps) {
           </NavLink>
           <NavLink href="/creator-wallets" active={pathname === "/creator-wallets"}>
             Creator Wallets
+          </NavLink>
+          <NavLink href="/founders-guide" active={pathname === "/founders-guide"}>
+            Founders Guide
           </NavLink>
         </nav>
       </div>


### PR DESCRIPTION
## Summary
- add Founders Guide nav item in the navbar
- expose Founders Guide URL through `NEXT_PUBLIC_FOUNDERS_GUIDE_DOC_URL`
- create `/founders-guide` route that embeds the Google Doc
- document new env var

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a9e780a38832ca264e44b7c1960ea