### PR TITLE
feat: founders-guide tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The cache admin interface is available at `/admin/cache`. This interface allows 
 - `KV_REST_API_TOKEN`: Your Upstash Redis API token
 - `ENABLE_DUNE_API`: Set to `true` to enable real Dune API calls (default: `false`)
 - `VERCEL_ENV`: Automatically set by Vercel to indicate the environment
+- `NEXT_PUBLIC_FOUNDERS_GUIDE_DOC_URL`: Public URL for the Founders Guide Google Document. Defaults to the live guide if unset.
 
 ## Cache Keys
 

--- a/app/founders-guide/page.tsx
+++ b/app/founders-guide/page.tsx
@@ -1,0 +1,41 @@
+import { Navbar } from "@/components/navbar";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Founders Guide | Dashcoin Research",
+};
+
+const DEFAULT_GUIDE_URL =
+  "https://docs.google.com/document/d/1fZHrmJOpcOIDzgYCkrqJk0yp8LM9kYXRISdChOthPv8/export?format=html";
+const GUIDE_URL =
+  process.env.NEXT_PUBLIC_FOUNDERS_GUIDE_DOC_URL || DEFAULT_GUIDE_URL;
+
+async function fetchGuideHtml() {
+  try {
+    const res = await fetch(GUIDE_URL, { cache: "force-cache" });
+    if (!res.ok) return null;
+    return res.text();
+  } catch {
+    return null;
+  }
+}
+
+export default async function FoundersGuidePage() {
+  const guideHtml = await fetchGuideHtml();
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar />
+      <main className="container mx-auto px-4 py-6 flex-1 flex flex-col gap-6">
+        <h1 className="dashcoin-text text-3xl text-dashYellow mb-2">Founders Guide</h1>
+        <article className="flex-1 min-h-[60vh] bg-dashGreen-dark rounded-md overflow-y-auto p-6 prose prose-invert text-dashYellow">
+          {guideHtml ? (
+            <div dangerouslySetInnerHTML={{ __html: guideHtml }} />
+          ) : (
+            <p className="dashcoin-text text-dashYellow-light">Guide not available.</p>
+          )}
+        </article>
+      </main>
+    </div>
+  );
+}
+

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -36,6 +36,9 @@ export function Navbar({ dashcStats }: NavbarProps) {
             <NavLink href="/creator-wallets" active={pathname === "/creator-wallets"}>
               Creator Wallets
             </NavLink>
+            <NavLink href="/founders-guide" active={pathname === "/founders-guide"}>
+              Founders Guide
+            </NavLink>
           </nav>
         </div>
       </div>
@@ -50,6 +53,9 @@ export function Navbar({ dashcStats }: NavbarProps) {
           </NavLink>
           <NavLink href="/creator-wallets" active={pathname === "/creator-wallets"}>
             Creator Wallets
+          </NavLink>
+          <NavLink href="/founders-guide" active={pathname === "/founders-guide"}>
+            Founders Guide
           </NavLink>
         </nav>
       </div>

--- a/public/screenshots/founders-guide-desktop.svg
+++ b/public/screenshots/founders-guide-desktop.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="600">
+  <rect width="800" height="600" fill="#1a1a1a" />
+  <text x="50%" y="50%" fill="#f5f5f5" font-size="24" text-anchor="middle" dominant-baseline="middle">
+    Founders Guide - Desktop (placeholder)
+  </text>
+</svg>

--- a/public/screenshots/founders-guide-mobile.svg
+++ b/public/screenshots/founders-guide-mobile.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="375" height="667">
+  <rect width="375" height="667" fill="#1a1a1a" />
+  <text x="50%" y="50%" fill="#f5f5f5" font-size="20" text-anchor="middle" dominant-baseline="middle">
+    Founders Guide - Mobile (placeholder)
+  </text>
+</svg>


### PR DESCRIPTION
## Summary
- add Founders Guide nav item in the navbar
- expose Founders Guide URL through `NEXT_PUBLIC_FOUNDERS_GUIDE_DOC_URL`
- render the guide server-side and style with dark theme
- add placeholder screenshots for desktop and mobile

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a9e780a38832ca264e44b7c1960ea