### PR TITLE
Update founders edge checklist labels

### DIFF
--- a/app/actions/googlesheet-action.ts
+++ b/app/actions/googlesheet-action.ts
@@ -23,9 +23,9 @@ export async function fetchTokenResearch(): Promise<ResearchScoreData[]> {
     const [header, ...rows] = data.values;
     
     const canonicalMap: Record<string, string> = {
-      'Startup Experience': 'Dev is Active on Twitter',
+      'Startup Experience': 'Prior Founder Experience',
       'Project Has Some Virality / Popularity':
-        'Project has 200k+ views on Social Media',
+        'Social Reach & Engagement Index',
     };
 
     const structured = rows.map((row: any) => {
@@ -46,12 +46,16 @@ export async function fetchTokenResearch(): Promise<ResearchScoreData[]> {
             ? parseFloat(entry['Score'])
             : null,
       };
-      ['Founder Doxxed',
-        'Dev is Active on Twitter',
-        'Successful Exit',
-        'Discussed Plans for Token Integration',
-        'Project has 200k+ views on Social Media',
-        'Live Product Exists'].forEach(label => {
+      [
+        'Team Doxxed',
+        'Twitter Activity Level',
+        'Time Commitment',
+        'Prior Founder Experience',
+        'Product Maturity',
+        'Funding Status',
+        'Token-Product Integration Depth',
+        'Social Reach & Engagement Index',
+      ].forEach(label => {
         result[label] = entry[label] ?? '';
       });
       return result as ResearchScoreData;

--- a/app/tokendetail/[symbol]/page.tsx
+++ b/app/tokendetail/[symbol]/page.tsx
@@ -30,12 +30,14 @@ import { FoundersEdgeChecklist } from "@/components/founders-edge-checklist";
 interface TokenResearchData {
   Symbol: string;
   Score: number | string;
-  "Founder Doxxed": number | string;
-  "Dev is Active on Twitter": number | string;
-  "Successful Exit": number | string;
-  "Discussed Plans for Token Integration": number | string;
-  "Project has 200k+ views on Social Media": number | string;
-  "Live Product Exists": number | string;
+  "Team Doxxed": number | string;
+  "Twitter Activity Level": number | string;
+  "Time Commitment": number | string;
+  "Prior Founder Experience": number | string;
+  "Product Maturity": number | string;
+  "Funding Status": number | string;
+  "Token-Product Integration Depth": number | string;
+  "Social Reach & Engagement Index": number | string;
   "Relevant Links": string;
   Comments: string;
   "Wallet Link": string;
@@ -65,9 +67,9 @@ async function fetchTokenResearch(
     const [header, ...rows] = data.values;
 
     const canonicalMap: Record<string, string> = {
-      "Startup Experience": "Dev is Active on Twitter",
+      "Startup Experience": "Prior Founder Experience",
       "Project Has Some Virality / Popularity":
-        "Project has 200k+ views on Social Media",
+        "Social Reach & Engagement Index",
     };
 
     const structured = rows.map((row: any) => {

--- a/components/founders-edge-checklist.tsx
+++ b/components/founders-edge-checklist.tsx
@@ -1,14 +1,17 @@
 import { DashcoinCard } from "@/components/ui/dashcoin-card";
 import { CheckCircle, XCircle, MinusCircle } from "lucide-react";
 import React from "react";
+import { gradeMaps, valueToScore } from "@/lib/score";
 
 export const canonicalChecklist = [
-  "Founder Doxxed",
-  "Dev is Active on Twitter",
-  "Successful Exit",
-  "Discussed Plans for Token Integration",
-  "Project has 200k+ views on Social Media",
-  "Live Product Exists",
+  "Team Doxxed",
+  "Twitter Activity Level",
+  "Time Commitment",
+  "Prior Founder Experience",
+  "Product Maturity",
+  "Funding Status",
+  "Token-Product Integration Depth",
+  "Social Reach & Engagement Index",
 ];
 
 function getIcon(value: number) {
@@ -50,7 +53,7 @@ export function FoundersEdgeChecklist({ data, showLegend = false }: ChecklistPro
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
         {canonicalChecklist.map((label) => {
           const raw = data[label];
-          const val = typeof raw === "string" ? parseInt(raw) : Number(raw);
+          const val = valueToScore(raw, (gradeMaps as any)[label]);
           return (
             <div
               key={label}

--- a/components/token-table.tsx
+++ b/components/token-table.tsx
@@ -12,6 +12,7 @@ import { batchFetchTokensData } from "@/app/actions/dexscreener-actions"
 import { useCallback } from "react"
 import { fetchTokenResearch } from "@/app/actions/googlesheet-action"
 import { canonicalChecklist } from "@/components/founders-edge-checklist"
+import { gradeMaps, valueToScore } from "@/lib/score"
 
 interface ResearchScoreData {
   symbol: string
@@ -117,7 +118,7 @@ export default function TokenTable({ data }: { data: PaginatedTokenResponse | To
         const filterVal = checklistFilters[label]
         if (!filterVal) return true
         const raw = research ? research[label] : null
-        const val = raw !== undefined && raw !== '' ? parseInt(raw) : null
+        const val = raw !== undefined && raw !== '' ? valueToScore(raw, (gradeMaps as any)[label]) : null
         if (filterVal === 'Yes') return val === 2
         if (filterVal === 'No') return val === 1
         if (filterVal === 'Unknown') return val !== 2 && val !== 1
@@ -533,7 +534,7 @@ export default function TokenTable({ data }: { data: PaginatedTokenResponse | To
                       </td>
                       {canonicalChecklist.map(label => {
                         const raw = (token as any)[label]
-                        const val = raw !== undefined && raw !== '' ? parseInt(raw) : null
+                        const val = raw !== undefined && raw !== '' ? valueToScore(raw, (gradeMaps as any)[label]) : null
                         const display = val === 2 ? 'Yes' : val === 1 ? 'No' : '-'
                         return (
                           <td key={label} className="py-3 px-4">{display}</td>

--- a/lib/score.js
+++ b/lib/score.js
@@ -1,0 +1,30 @@
+export const gradeMaps = {
+  default: {
+    '2': 2,
+    '1': 1,
+    '0': 0,
+    2: 2,
+    1: 1,
+    0: 0,
+    Yes: 2,
+    No: 1,
+    Unknown: 0,
+    '': 0,
+  },
+};
+
+export function valueToScore(value, map = gradeMaps.default) {
+  if (value === null || value === undefined) return 0;
+  if (typeof value === 'number') {
+    return value;
+  }
+  const key = value.toString().trim();
+  if (map && Object.prototype.hasOwnProperty.call(map, key)) {
+    return map[key];
+  }
+  if (Object.prototype.hasOwnProperty.call(gradeMaps.default, key)) {
+    return gradeMaps.default[key];
+  }
+  const num = parseInt(key, 10);
+  return isNaN(num) ? 0 : num;
+}


### PR DESCRIPTION
## Summary
- update `FoundersEdgeChecklist` items
- introduce `gradeMaps` helper and use it to derive numeric scores
- display new checklist labels throughout token table
- adjust research fetchers for new checklist column names

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683aac2bfbc4832c9ea1e511a4b09ae4