### PR TITLE
feat: style founders guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The cache admin interface is available at `/admin/cache`. This interface allows 
 - `KV_REST_API_TOKEN`: Your Upstash Redis API token
 - `ENABLE_DUNE_API`: Set to `true` to enable real Dune API calls (default: `false`)
 - `VERCEL_ENV`: Automatically set by Vercel to indicate the environment
+- `NEXT_PUBLIC_FOUNDERS_GUIDE_DOC_URL`: Public URL for the Founders Guide Google Document (defaults to the live guide)
 
 ## Cache Keys
 

--- a/app/founders-guide/page.tsx
+++ b/app/founders-guide/page.tsx
@@ -1,0 +1,42 @@
+import { Navbar } from "@/components/navbar";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Founders Guide | Dashcoin Research",
+};
+
+const DEFAULT_GUIDE_URL =
+  "https://docs.google.com/document/d/1fZHrmJOpcOIDzgYCkrqJk0yp8LM9kYXRISdChOthPv8/export?format=html";
+
+const GUIDE_URL =
+  process.env.NEXT_PUBLIC_FOUNDERS_GUIDE_DOC_URL || DEFAULT_GUIDE_URL;
+
+async function fetchGuideHtml(): Promise<string> {
+  try {
+    const res = await fetch(GUIDE_URL, { next: { revalidate: 3600 } });
+    if (!res.ok) {
+      throw new Error(`Failed to fetch guide: ${res.status} ${res.statusText}`);
+    }
+    return await res.text();
+  } catch (error) {
+    console.error("Error fetching guide", error);
+    return "<p>Unable to load guide.</p>";
+  }
+}
+
+export default async function FoundersGuidePage() {
+  const guideHtml = await fetchGuideHtml();
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar />
+      <main className="container mx-auto px-4 py-6 flex-1 flex flex-col gap-6">
+        <h1 className="dashcoin-text text-3xl text-dashYellow mb-2">Founders Guide</h1>
+        <article
+          className="founders-guide prose prose-invert mx-auto"
+          dangerouslySetInnerHTML={{ __html: guideHtml }}
+        />
+      </main>
+    </div>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -253,3 +253,13 @@
   background: transparent !important;
   color: inherit !important;
 }
+
+/* Founders Guide adjustments */
+.founders-guide {
+  font-size: 125%;
+  line-height: 1.4;
+}
+
+.founders-guide p {
+  margin: 0.5rem 0;
+}

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -36,6 +36,9 @@ export function Navbar({ dashcStats }: NavbarProps) {
             <NavLink href="/creator-wallets" active={pathname === "/creator-wallets"}>
               Creator Wallets
             </NavLink>
+            <NavLink href="/founders-guide" active={pathname === "/founders-guide"}>
+              Founders Guide
+            </NavLink>
           </nav>
         </div>
       </div>
@@ -50,6 +53,9 @@ export function Navbar({ dashcStats }: NavbarProps) {
           </NavLink>
           <NavLink href="/creator-wallets" active={pathname === "/creator-wallets"}>
             Creator Wallets
+          </NavLink>
+          <NavLink href="/founders-guide" active={pathname === "/founders-guide"}>
+            Founders Guide
           </NavLink>
         </nav>
       </div>


### PR DESCRIPTION
## Summary
- fetch guide HTML server-side and render as article
- center guide on the page with larger text and tighter spacing
- document default guide URL

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a9e780a38832ca264e44b7c1960ea