### PR TITLE
feat: founders-guide tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ The cache admin interface is available at `/admin/cache`. This interface allows 
 - `KV_REST_API_TOKEN`: Your Upstash Redis API token
 - `ENABLE_DUNE_API`: Set to `true` to enable real Dune API calls (default: `false`)
 - `VERCEL_ENV`: Automatically set by Vercel to indicate the environment
+- `NEXT_PUBLIC_FOUNDERS_GUIDE_DOC_URL`: Public URL for the Founders Guide Google Document
+  (defaults to the published Believe Founder Guide if unset)
 
 ## Cache Keys
 

--- a/app/founders-guide/page.tsx
+++ b/app/founders-guide/page.tsx
@@ -1,0 +1,27 @@
+import { Navbar } from "@/components/navbar";
+import type { Metadata } from "next";
+import { fetchFoundersGuideHtml } from "@/lib/founders-guide";
+
+export const metadata: Metadata = {
+  title: "Founders Guide | Dashcoin Research",
+};
+
+export default async function FoundersGuidePage() {
+  const html = await fetchFoundersGuideHtml();
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar />
+      <main className="container mx-auto px-4 py-6 flex-1">
+        <h1 className="dashcoin-text text-dashYellow text-center text-4xl mb-4">
+          Founder&apos;s Guide
+        </h1>
+        <article
+          className="founders-guide prose prose-invert w-full mx-auto max-w-prose"
+          dangerouslySetInnerHTML={{ __html: html }}
+        />
+      </main>
+    </div>
+  );
+}
+

--- a/app/globals.css
+++ b/app/globals.css
@@ -253,3 +253,22 @@
   background: transparent !important;
   color: inherit !important;
 }
+
+/* Founders Guide styling */
+.founders-guide {
+  font-size: 1.25rem; /* enlarge text */
+  line-height: 1.6;
+  background: var(--dashcoin-green-dark);
+  color: var(--dashcoin-yellow);
+  padding: 1rem;
+  border-radius: 0.5rem;
+}
+
+.founders-guide h1 {
+  text-align: center;
+}
+
+.founders-guide p,
+.founders-guide li {
+  margin-bottom: 0.5rem;
+}

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -36,6 +36,9 @@ export function Navbar({ dashcStats }: NavbarProps) {
             <NavLink href="/creator-wallets" active={pathname === "/creator-wallets"}>
               Creator Wallets
             </NavLink>
+            <NavLink href="/founders-guide" active={pathname === "/founders-guide"}>
+              Founders Guide
+            </NavLink>
           </nav>
         </div>
       </div>
@@ -50,6 +53,9 @@ export function Navbar({ dashcStats }: NavbarProps) {
           </NavLink>
           <NavLink href="/creator-wallets" active={pathname === "/creator-wallets"}>
             Creator Wallets
+          </NavLink>
+          <NavLink href="/founders-guide" active={pathname === "/founders-guide"}>
+            Founders Guide
           </NavLink>
         </nav>
       </div>

--- a/lib/founders-guide.ts
+++ b/lib/founders-guide.ts
@@ -1,0 +1,15 @@
+export async function fetchFoundersGuideHtml() {
+  const url =
+    process.env.NEXT_PUBLIC_FOUNDERS_GUIDE_DOC_URL ||
+    'https://docs.google.com/document/d/1fZHrmJOpcOIDzgYCkrqJk0yp8LM9kYXRISdChOthPv8/export?format=html';
+  try {
+    const res = await fetch(url);
+    if (!res.ok) {
+      throw new Error('Failed to fetch guide');
+    }
+    return await res.text();
+  } catch (err) {
+    console.error(err);
+    return '<p>Unable to load guide.</p>';
+  }
+}


### PR DESCRIPTION
## Summary
- add docs URL env var note
- fetch Founder's Guide HTML server-side and style it
- center title and enlarge text

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a9e780a38832ca264e44b7c1960ea