### PR TITLE
Refine token tables

### DIFF
--- a/app/actions/googlesheet-action.ts
+++ b/app/actions/googlesheet-action.ts
@@ -23,9 +23,9 @@ export async function fetchTokenResearch(): Promise<ResearchScoreData[]> {
     const [header, ...rows] = data.values;
     
     const canonicalMap: Record<string, string> = {
-      'Startup Experience': 'Dev is Active on Twitter',
+      'Startup Experience': 'Prior Founder Experience',
       'Project Has Some Virality / Popularity':
-        'Project has 200k+ views on Social Media',
+        'Social Reach & Engagement Index',
     };
 
     const structured = rows.map((row: any) => {
@@ -46,12 +46,16 @@ export async function fetchTokenResearch(): Promise<ResearchScoreData[]> {
             ? parseFloat(entry['Score'])
             : null,
       };
-      ['Founder Doxxed',
-        'Dev is Active on Twitter',
-        'Successful Exit',
-        'Discussed Plans for Token Integration',
-        'Project has 200k+ views on Social Media',
-        'Live Product Exists'].forEach(label => {
+      [
+        'Team Doxxed',
+        'Twitter Activity Level',
+        'Time Commitment',
+        'Prior Founder Experience',
+        'Product Maturity',
+        'Funding Status',
+        'Token-Product Integration Depth',
+        'Social Reach & Engagement Index',
+      ].forEach(label => {
         result[label] = entry[label] ?? '';
       });
       return result as ResearchScoreData;

--- a/app/tokendetail/[symbol]/page.tsx
+++ b/app/tokendetail/[symbol]/page.tsx
@@ -30,12 +30,14 @@ import { FoundersEdgeChecklist } from "@/components/founders-edge-checklist";
 interface TokenResearchData {
   Symbol: string;
   Score: number | string;
-  "Founder Doxxed": number | string;
-  "Dev is Active on Twitter": number | string;
-  "Successful Exit": number | string;
-  "Discussed Plans for Token Integration": number | string;
-  "Project has 200k+ views on Social Media": number | string;
-  "Live Product Exists": number | string;
+  "Team Doxxed": number | string;
+  "Twitter Activity Level": number | string;
+  "Time Commitment": number | string;
+  "Prior Founder Experience": number | string;
+  "Product Maturity": number | string;
+  "Funding Status": number | string;
+  "Token-Product Integration Depth": number | string;
+  "Social Reach & Engagement Index": number | string;
   "Relevant Links": string;
   Comments: string;
   "Wallet Link": string;
@@ -65,9 +67,9 @@ async function fetchTokenResearch(
     const [header, ...rows] = data.values;
 
     const canonicalMap: Record<string, string> = {
-      "Startup Experience": "Dev is Active on Twitter",
+      "Startup Experience": "Prior Founder Experience",
       "Project Has Some Virality / Popularity":
-        "Project has 200k+ views on Social Media",
+        "Social Reach & Engagement Index",
     };
 
     const structured = rows.map((row: any) => {

--- a/components/founders-edge-checklist.tsx
+++ b/components/founders-edge-checklist.tsx
@@ -1,14 +1,17 @@
 import { DashcoinCard } from "@/components/ui/dashcoin-card";
 import { CheckCircle, XCircle, MinusCircle } from "lucide-react";
 import React from "react";
+import { gradeMaps, valueToScore } from "@/lib/score";
 
 export const canonicalChecklist = [
-  "Founder Doxxed",
-  "Dev is Active on Twitter",
-  "Successful Exit",
-  "Discussed Plans for Token Integration",
-  "Project has 200k+ views on Social Media",
-  "Live Product Exists",
+  "Team Doxxed",
+  "Twitter Activity Level",
+  "Time Commitment",
+  "Prior Founder Experience",
+  "Product Maturity",
+  "Funding Status",
+  "Token-Product Integration Depth",
+  "Social Reach & Engagement Index",
 ];
 
 function getIcon(value: number) {
@@ -50,7 +53,7 @@ export function FoundersEdgeChecklist({ data, showLegend = false }: ChecklistPro
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
         {canonicalChecklist.map((label) => {
           const raw = data[label];
-          const val = typeof raw === "string" ? parseInt(raw) : Number(raw);
+          const val = valueToScore(raw, (gradeMaps as any)[label]);
           return (
             <div
               key={label}

--- a/components/new-tokens-table.tsx
+++ b/components/new-tokens-table.tsx
@@ -1,7 +1,7 @@
 import { DashcoinButton } from "@/components/ui/dashcoin-button"
 import { DashcoinCard, DashcoinCardHeader, DashcoinCardTitle, DashcoinCardContent } from "@/components/ui/dashcoin-card"
 import type { NewTokenData } from "@/types/dune"
-import { formatCurrency } from "@/lib/utils"
+import { formatCurrency0 } from "@/lib/utils"
 import { CopyAddress } from "@/components/copy-address"
 
 interface NewTokensTableProps {
@@ -23,10 +23,8 @@ export function NewTokensTable({ data }: NewTokensTableProps) {
             <thead>
               <tr className="bg-dashBlue-dark border-b border-dashBlack">
                 <th className="text-left py-2 px-4 text-dashYellow">Symbol</th>
-                <th className="text-left py-2 px-4 text-dashYellow">Created</th>
                 <th className="text-left py-2 px-4 text-dashYellow">Market Cap</th>
-                <th className="text-left py-2 px-4 text-dashYellow">Holders</th>
-                <th className="text-left py-2 px-4 text-dashYellow">Actions</th>
+                <th className="text-left py-2 px-4 text-dashYellow w-[60px]">Actions</th>
               </tr>
             </thead>
             <tbody>
@@ -34,14 +32,7 @@ export function NewTokensTable({ data }: NewTokensTableProps) {
                 filteredTokens.map((token, index) => {
                   const tokenAddress = token?.token_mint_address || ""
                   const tokenSymbol = token?.symbol || "???"
-                  const createdTime = token?.created_time
-                    ? new Date(token.created_time).toLocaleString(undefined, {
-                        dateStyle: "short",
-                        timeStyle: "short",
-                      })
-                    : "N/A"
-                  const marketCap = token?.market_cap_usd ? formatCurrency(token.market_cap_usd) : "N/A"
-                  const holders = token?.num_holders || 0
+                  const marketCap = token?.market_cap_usd ? formatCurrency0(token.market_cap_usd) : "N/A"
 
                   return (
                     <tr key={index} className="border-b border-dashBlue-light hover:bg-dashBlue-dark">
@@ -57,11 +48,13 @@ export function NewTokensTable({ data }: NewTokensTableProps) {
                           )}
                         </div>
                       </td>
-                      <td className="py-2 px-4">{createdTime}</td>
                       <td className="py-2 px-4">{marketCap}</td>
-                      <td className="py-2 px-4">{holders}</td>
                       <td className="py-2 px-4">
-                        <DashcoinButton variant="outline" size="sm" className="h-7 text-xs py-0">
+                        <DashcoinButton
+                          variant="outline"
+                          size="sm"
+                          className="h-7 text-xs py-0 px-2 min-w-[60px]"
+                        >
                           TRADE
                         </DashcoinButton>
                       </td>
@@ -70,7 +63,7 @@ export function NewTokensTable({ data }: NewTokensTableProps) {
                 })
               ) : (
                 <tr>
-                  <td colSpan={5} className="py-4 text-center opacity-80">
+                  <td colSpan={3} className="py-4 text-center opacity-80">
                     No new tokens with market cap above $10,000 available
                   </td>
                 </tr>

--- a/components/token-table.tsx
+++ b/components/token-table.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef } from "react"
 import Link from "next/link"
-import { formatCurrency } from "@/lib/utils"
+import { formatCurrency0 } from "@/lib/utils"
 import { DashcoinCard } from "@/components/ui/dashcoin-card"
 import { ChevronDown, ChevronUp, Search, Loader2, FileSearch, Filter } from "lucide-react"
 import { fetchPaginatedTokens } from "@/app/actions/dune-actions"
@@ -12,6 +12,7 @@ import { batchFetchTokensData } from "@/app/actions/dexscreener-actions"
 import { useCallback } from "react"
 import { fetchTokenResearch } from "@/app/actions/googlesheet-action"
 import { canonicalChecklist } from "@/components/founders-edge-checklist"
+import { gradeMaps, valueToScore } from "@/lib/score"
 
 interface ResearchScoreData {
   symbol: string
@@ -117,7 +118,7 @@ export default function TokenTable({ data }: { data: PaginatedTokenResponse | To
         const filterVal = checklistFilters[label]
         if (!filterVal) return true
         const raw = research ? research[label] : null
-        const val = raw !== undefined && raw !== '' ? parseInt(raw) : null
+        const val = raw !== undefined && raw !== '' ? valueToScore(raw, (gradeMaps as any)[label]) : null
         if (filterVal === 'Yes') return val === 2
         if (filterVal === 'No') return val === 1
         if (filterVal === 'Unknown') return val !== 2 && val !== 1
@@ -253,7 +254,7 @@ export default function TokenTable({ data }: { data: PaginatedTokenResponse | To
       setSortDirection("desc");
     }
     
-    setIsSortingLocally(["researchScore", "name", "created_time", "symbol", "marketCap"].includes(field));
+    setIsSortingLocally(["researchScore", "name", "symbol", "marketCap"].includes(field));
     setCurrentPage(1);
   }
 
@@ -278,12 +279,6 @@ export default function TokenTable({ data }: { data: PaginatedTokenResponse | To
             ? valueA.localeCompare(valueB)
             : valueB.localeCompare(valueA);
             
-        case "created_time":
-          valueA = a.created_time ? new Date(a.created_time).getTime() : 0;
-          valueB = b.created_time ? new Date(b.created_time).getTime() : 0;
-          return sortDirection === "asc" 
-            ? valueA - valueB
-            : valueB - valueA;
             
         case "researchScore":
           const scoreA = getResearchScore(a.symbol || '');
@@ -351,8 +346,7 @@ export default function TokenTable({ data }: { data: PaginatedTokenResponse | To
             className="px-3 py-2 bg-dashGreen-dark border border-dashBlack rounded-md text-dashYellow-light focus:outline-none focus:ring-2 focus:ring-dashYellow"
           >
             <option value="marketCap">Market Cap</option>
-            <option value="num_holders">Holders</option>
-            <option value="created_time">Created Date</option>
+            
             <option value="symbol">Token</option>
             <option value="researchScore">Research Score</option>
             <option value="change24h">24h %Gain</option>
@@ -389,7 +383,7 @@ export default function TokenTable({ data }: { data: PaginatedTokenResponse | To
                 <th className="text-left py-3 px-4 text-dashYellow cursor-pointer" onClick={() => handleSort("symbol")}>
                   <div className="flex items-center gap-1">Token {renderSortIndicator("symbol")}</div>
                 </th>
-                <th className="text-left py-3 px-4 text-dashYellow">Actions</th>
+                <th className="text-left py-3 px-4 text-dashYellow w-[60px]">Actions</th>
                 <th
                   className="text-left py-3 px-4 text-dashYellow cursor-pointer"
                   onClick={() => handleSort("marketCap")}
@@ -401,18 +395,6 @@ export default function TokenTable({ data }: { data: PaginatedTokenResponse | To
                   onClick={() => handleSort("change24h")}
                 >
                   <div className="flex items-center gap-1">24h %Gain {renderSortIndicator("change24h")}</div>
-                </th>
-                <th
-                  className="text-left py-3 px-4 text-dashYellow cursor-pointer"
-                  onClick={() => handleSort("num_holders")}
-                >
-                  <div className="flex items-center gap-1">Holders {renderSortIndicator("num_holders")}</div>
-                </th>
-                <th
-                  className="text-left py-3 px-4 text-dashYellow cursor-pointer"
-                  onClick={() => handleSort("created_time")}
-                >
-                  <div className="flex items-center gap-1">Created {renderSortIndicator("created_time")}</div>
                 </th>
                 <th 
                   className="text-left py-3 px-4 text-dashYellow cursor-pointer"
@@ -498,21 +480,17 @@ export default function TokenTable({ data }: { data: PaginatedTokenResponse | To
                             href={tokenAddress ? `https://axiom.trade/t/${tokenAddress}/dashc` : "#"}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="px-3 py-1.5 bg-dashYellow text-dashBlack font-medium rounded-md hover:bg-dashYellow-dark transition-colors text-sm flex items-center justify-center min-w-[80px] border border-dashBlack"
+                            className="px-2 py-1.5 bg-dashYellow text-dashBlack font-medium rounded-md hover:bg-dashYellow-dark transition-colors text-sm flex items-center justify-center min-w-[60px] border border-dashBlack"
                           >
                             TRADE
                           </a>
                         </div>
                       </td>
-                      <td className="py-3 px-4">{formatCurrency(getTokenProperty(token, "marketCap", 0))}</td>
+                      <td className="py-3 px-4">{formatCurrency0(getTokenProperty(token, "marketCap", 0))}</td>
                       <td className="py-3 px-4">
                         <div className={`${token.change24h > 0 ? 'text-green-500' : token.change24h < 0 ? 'text-red-500' : ''}`}>
                           {getTokenProperty(token, "change24h", 0).toFixed(2)}%
                         </div>
-                      </td>
-                      <td className="py-3 px-4">{getTokenProperty(token, "num_holders", 0).toLocaleString()}</td>
-                      <td className="py-3 px-4">
-                        {token && token.created_time ? new Date(token.created_time).toLocaleDateString() : "N/A"}
                       </td>
                       <td className="py-3 px-4">
                         {isLoadingResearch ? (
@@ -533,7 +511,7 @@ export default function TokenTable({ data }: { data: PaginatedTokenResponse | To
                       </td>
                       {canonicalChecklist.map(label => {
                         const raw = (token as any)[label]
-                        const val = raw !== undefined && raw !== '' ? parseInt(raw) : null
+                        const val = raw !== undefined && raw !== '' ? valueToScore(raw, (gradeMaps as any)[label]) : null
                         const display = val === 2 ? 'Yes' : val === 1 ? 'No' : '-'
                         return (
                           <td key={label} className="py-3 px-4">{display}</td>

--- a/lib/score.js
+++ b/lib/score.js
@@ -1,0 +1,30 @@
+export const gradeMaps = {
+  default: {
+    '2': 2,
+    '1': 1,
+    '0': 0,
+    2: 2,
+    1: 1,
+    0: 0,
+    Yes: 2,
+    No: 1,
+    Unknown: 0,
+    '': 0,
+  },
+};
+
+export function valueToScore(value, map = gradeMaps.default) {
+  if (value === null || value === undefined) return 0;
+  if (typeof value === 'number') {
+    return value;
+  }
+  const key = value.toString().trim();
+  if (map && Object.prototype.hasOwnProperty.call(map, key)) {
+    return map[key];
+  }
+  if (Object.prototype.hasOwnProperty.call(gradeMaps.default, key)) {
+    return gradeMaps.default[key];
+  }
+  const num = parseInt(key, 10);
+  return isNaN(num) ? 0 : num;
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -10,6 +10,15 @@ export const formatCurrency = (amount: number): string => {
   }).format(amount)
 }
 
+export const formatCurrency0 = (amount: number): string => {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(amount)
+}
+
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }


### PR DESCRIPTION
## Summary
- drop holders and created date columns
- tweak actions column widths and button sizes
- format market cap with no decimals

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683aac2bfbc4832c9ea1e511a4b09ae4