### PR TITLE
feat: adopt v2025-05-30 research score

### DIFF
--- a/__tests__/score.test.js
+++ b/__tests__/score.test.js
@@ -1,0 +1,16 @@
+import assert from 'node:assert';
+import { computeScoreFallback } from '../lib/score.js';
+
+const sample = {
+  'Team Doxxed': 'No',
+  'Twitter Activity Level': 'Unknown',
+  'Time Commitment': 'Part-time / side-project',
+  'Prior Founder Experience': 'No',
+  'Product Maturity': 'Concept only (white-paper / roadmap)',
+  'Funding Status': 'Angel Investors',
+  'Token-Product Integration Depth': 'No',
+  'Social Reach & Engagement Index': 'Unknown',
+};
+
+const score = computeScoreFallback(sample);
+assert.equal(score, 38);

--- a/__tests__/sheet-score.test.js
+++ b/__tests__/sheet-score.test.js
@@ -1,0 +1,23 @@
+import test from 'node:test';
+import assert from 'node:assert';
+const API_KEY = 'AIzaSyC8QxJez_UTHUJS7vFj1J3Sje0CWS9tXyk';
+const SHEET_ID = '1Nra5QH-JFAsDaTYSyu-KocjbkZ0MATzJ4R-rUt-gLe0';
+const SHEET_NAME = 'Dashcoin Scoring';
+const RANGE = `${SHEET_NAME}!A1:L200`;
+const url = `https://sheets.googleapis.com/v4/spreadsheets/${SHEET_ID}/values/${RANGE}?key=${API_KEY}`;
+
+test('all rows have valid score', async (t) => {
+  try {
+    const res = await fetch(url);
+    const data = await res.json();
+    const [header, ...rows] = data.values || [];
+    const scoreIndex = header.indexOf('Score');
+    for (const row of rows) {
+      const score = parseFloat(row[scoreIndex]);
+      assert.equal(typeof score, 'number');
+      assert.ok(!Number.isNaN(score));
+    }
+  } catch (err) {
+    t.skip('Network unavailable');
+  }
+});

--- a/app/actions/googlesheet-action.ts
+++ b/app/actions/googlesheet-action.ts
@@ -4,11 +4,14 @@ interface ResearchScoreData {
   [key: string]: any
 }
 
+import { canonicalChecklist } from '@/components/founders-edge-checklist';
+import { computeScoreFallback } from '@/lib/score';
+
 export async function fetchTokenResearch(): Promise<ResearchScoreData[]> {
   const API_KEY = 'AIzaSyC8QxJez_UTHUJS7vFj1J3Sje0CWS9tXyk';
   const SHEET_ID = '1Nra5QH-JFAsDaTYSyu-KocjbkZ0MATzJ4R-rUt-gLe0';
   const SHEET_NAME = 'Dashcoin Scoring';
-  const RANGE = `${SHEET_NAME}!A1:T200`;
+  const RANGE = `${SHEET_NAME}!A1:L200`;
   const url = `https://sheets.googleapis.com/v4/spreadsheets/${SHEET_ID}/values/${RANGE}?key=${API_KEY}`;
 
   try {
@@ -46,18 +49,14 @@ export async function fetchTokenResearch(): Promise<ResearchScoreData[]> {
             ? parseFloat(entry['Score'])
             : null,
       };
-      [
-        'Team Doxxed',
-        'Twitter Activity Level',
-        'Time Commitment',
-        'Prior Founder Experience',
-        'Product Maturity',
-        'Funding Status',
-        'Token-Product Integration Depth',
-        'Social Reach & Engagement Index',
-      ].forEach(label => {
+      canonicalChecklist.forEach(label => {
         result[label] = entry[label] ?? '';
       });
+
+      if (result.score === null || Number.isNaN(result.score)) {
+        result.score = computeScoreFallback(result);
+      }
+
       return result as ResearchScoreData;
     });
   } catch (err) {

--- a/app/api/projects/route.ts
+++ b/app/api/projects/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server';
+import { fetchTokenResearch } from '@/app/actions/googlesheet-action';
+
+export const revalidate = 300;
+
+export async function GET() {
+  try {
+    const data = await fetchTokenResearch();
+    return NextResponse.json(data);
+  } catch (err) {
+    console.error('Error fetching projects:', err);
+    return new NextResponse(JSON.stringify({ error: 'Failed to fetch projects' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+}

--- a/lib/score.js
+++ b/lib/score.js
@@ -11,6 +11,26 @@ export const gradeMaps = {
     Unknown: 0,
     '': 0,
   },
+  'Time Commitment': {
+    'Full-time': 2,
+    'Part-time / side-project': 1,
+    Unknown: 0,
+    '': 0,
+  },
+  'Funding Status': {
+    'VC / institutional investors': 2,
+    'Angel Investors': 1,
+    Bootstrapped: 1,
+    Unknown: 0,
+    '': 0,
+  },
+  'Product Maturity': {
+    'Live product': 2,
+    'MVP / Beta': 1,
+    'Concept only (white-paper / roadmap)': 1,
+    Unknown: 0,
+    '': 0,
+  },
 };
 
 export function valueToScore(value, map = gradeMaps.default) {
@@ -27,4 +47,27 @@ export function valueToScore(value, map = gradeMaps.default) {
   }
   const num = parseInt(key, 10);
   return isNaN(num) ? 0 : num;
+}
+
+export function computeScoreFallback(entry) {
+  if (!entry) return 0;
+  const fields = [
+    'Team Doxxed',
+    'Twitter Activity Level',
+    'Time Commitment',
+    'Prior Founder Experience',
+    'Product Maturity',
+    'Funding Status',
+    'Token-Product Integration Depth',
+    'Social Reach & Engagement Index',
+  ];
+
+  let total = 0;
+  fields.forEach(label => {
+    const raw = entry[label];
+    const map = gradeMaps[label] || gradeMaps.default;
+    total += valueToScore(raw, map);
+  });
+  const score = Math.round((total / (fields.length * 2)) * 100);
+  return score;
 }


### PR DESCRIPTION
## Summary
- update research rubric labels and scoring utilities
- pull only the required sheet columns and compute missing scores
- expose research data at `/api/projects` with ISR
- improve `TokenTable` research features
- sync token detail page with new scoring
- add tests for rubric fallback and sheet integrity

## Testing
- `npm test` *(fails: Network unavailable for sheet check)*

------
https://chatgpt.com/codex/tasks/task_e_683ab7498e8c832ca9936f874bb21356