### PR TITLE
feat: founders-guide tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The cache admin interface is available at `/admin/cache`. This interface allows 
 - `KV_REST_API_TOKEN`: Your Upstash Redis API token
 - `ENABLE_DUNE_API`: Set to `true` to enable real Dune API calls (default: `false`)
 - `VERCEL_ENV`: Automatically set by Vercel to indicate the environment
+- `NEXT_PUBLIC_FOUNDERS_GUIDE_DOC_URL`: URL of the Founders Guide Google Document. Defaults to the published guide if unset.
 
 ## Cache Keys
 

--- a/app/founders-guide/page.tsx
+++ b/app/founders-guide/page.tsx
@@ -1,0 +1,27 @@
+import { Navbar } from "@/components/navbar";
+import type { Metadata } from "next";
+import { fetchFoundersGuideHtml } from "@/lib/fetchFoundersGuideHtml";
+
+export const metadata: Metadata = {
+  title: "Founders Guide | Dashcoin Research",
+};
+
+export default async function FoundersGuidePage() {
+  const html = await fetchFoundersGuideHtml();
+
+  return (
+    <div className="min-h-screen">
+      <Navbar />
+      <main className="container mx-auto px-4 py-6">
+        <h1 className="dashcoin-text text-3xl text-dashYellow text-center mb-4">
+          Founder's Guide
+        </h1>
+        <article
+          className="founders-guide"
+          dangerouslySetInnerHTML={{ __html: html }}
+        />
+      </main>
+    </div>
+  );
+}
+

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -36,6 +36,9 @@ export function Navbar({ dashcStats }: NavbarProps) {
             <NavLink href="/creator-wallets" active={pathname === "/creator-wallets"}>
               Creator Wallets
             </NavLink>
+            <NavLink href="/founders-guide" active={pathname === "/founders-guide"}>
+              Founders Guide
+            </NavLink>
           </nav>
         </div>
       </div>
@@ -50,6 +53,9 @@ export function Navbar({ dashcStats }: NavbarProps) {
           </NavLink>
           <NavLink href="/creator-wallets" active={pathname === "/creator-wallets"}>
             Creator Wallets
+          </NavLink>
+          <NavLink href="/founders-guide" active={pathname === "/founders-guide"}>
+            Founders Guide
           </NavLink>
         </nav>
       </div>

--- a/lib/fetchFoundersGuideHtml.ts
+++ b/lib/fetchFoundersGuideHtml.ts
@@ -1,0 +1,16 @@
+export async function fetchFoundersGuideHtml(): Promise<string> {
+  const defaultUrl =
+    "https://docs.google.com/document/d/1fZHrmJOpcOIDzgYCkrqJk0yp8LM9kYXRISdChOthPv8/export?format=html";
+  const url = process.env.NEXT_PUBLIC_FOUNDERS_GUIDE_DOC_URL || defaultUrl;
+  try {
+    const res = await fetch(url);
+    if (!res.ok) {
+      console.error(`Failed to fetch guide: ${res.statusText}`);
+      return "<p>Failed to load guide.</p>";
+    }
+    return await res.text();
+  } catch (error) {
+    console.error("Error fetching founders guide:", error);
+    return "<p>Failed to load guide.</p>";
+  }
+}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -143,3 +143,11 @@ body {
     @apply bg-background text-foreground;
   }
 }
+
+/* Founders Guide article styles */
+.founders-guide {
+  @apply prose prose-invert mx-auto text-[1.25rem] leading-relaxed max-w-3xl;
+}
+.founders-guide p {
+  @apply my-2;
+}


### PR DESCRIPTION
## Summary
- document `NEXT_PUBLIC_FOUNDERS_GUIDE_DOC_URL` default
- fetch Founders Guide HTML server-side
- style guide page for centered title and larger text
- add Founders Guide article styles

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683a9e780a38832ca264e44b7c1960ea