### PR TITLE
Add Founder's Guide page

### DIFF
--- a/app/founders-guide/page.tsx
+++ b/app/founders-guide/page.tsx
@@ -1,0 +1,42 @@
+import { Navbar } from "@/components/navbar";
+import FoundersGuide from "@/components/founders-guide";
+import ScrollProgress from "@/components/scroll-progress";
+
+export const metadata = {
+  title: "Believe Founder's Guide",
+};
+
+async function getGuideHtml() {
+  const id = process.env.FOUNDERS_GUIDE_DOC_ID;
+  if (!id) return null;
+  try {
+    const res = await fetch(
+      `https://docs.google.com/document/d/${id}/export?format=html`
+    );
+    if (!res.ok) return null;
+    return await res.text();
+  } catch (err) {
+    console.error("Failed to fetch founders guide", err);
+    return null;
+  }
+}
+
+export default async function Page() {
+  const html = await getGuideHtml();
+  return (
+    <div className="min-h-screen">
+      <Navbar />
+      <ScrollProgress />
+      {html ? (
+        <FoundersGuide html={html} />
+      ) : (
+        <div className="container mx-auto px-4 py-12">
+          <h1 className="text-3xl mb-4 text-dashYellow">Founder's Guide</h1>
+          <p className="text-dashYellow-light">
+            Unable to load the guide at this time.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/founders-guide.tsx
+++ b/components/founders-guide.tsx
@@ -1,0 +1,82 @@
+"use client";
+import { useEffect, useState, useRef } from "react";
+import ThemeToggle from "./theme-toggle";
+
+interface Heading {
+  id: string;
+  text: string;
+  level: number;
+}
+
+export default function FoundersGuide({ html }: { html: string }) {
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [headings, setHeadings] = useState<Heading[]>([]);
+  const [active, setActive] = useState<string>("");
+
+  // create slug from text
+  const slugify = (str: string) =>
+    str
+      .toLowerCase()
+      .replace(/[^a-z0-9\s-]/g, "")
+      .trim()
+      .replace(/\s+/g, "-");
+
+  useEffect(() => {
+    if (!contentRef.current) return;
+    const nodes = Array.from(
+      contentRef.current.querySelectorAll<HTMLElement>("h1, h2, h3")
+    );
+    const list: Heading[] = nodes.map((node) => {
+      let id = node.id;
+      if (!id) {
+        id = slugify(node.textContent || "");
+        node.id = id;
+      }
+      return { id, text: node.textContent || "", level: parseInt(node.tagName[1]) };
+    });
+    setHeadings(list);
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) setActive(entry.target.id);
+        });
+      },
+      { rootMargin: "0px 0px -80% 0px" }
+    );
+    nodes.forEach((n) => observer.observe(n));
+    return () => nodes.forEach((n) => observer.unobserve(n));
+  }, [html]);
+
+  return (
+    <div className="container mx-auto px-4 py-8 flex gap-8">
+      <aside className="hidden lg:block w-64 sticky top-24 self-start">
+        <div className="flex justify-between items-center mb-4">
+          <h2 className="text-lg font-semibold text-dashYellow">Contents</h2>
+          <ThemeToggle />
+        </div>
+        <ul className="space-y-1 text-sm">
+          {headings.map((h) => (
+            <li key={h.id} className={`pl-${(h.level - 1) * 4}`}>
+              <a
+                href={`#${h.id}`}
+                className={
+                  active === h.id
+                    ? "text-dashYellow"
+                    : "text-dashYellow-light hover:text-dashYellow"
+                }
+              >
+                {h.text}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </aside>
+      <article
+        ref={contentRef}
+        className="prose dark:prose-invert max-w-prose w-full"
+        dangerouslySetInnerHTML={{ __html: html }}
+      />
+    </div>
+  );
+}

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -36,6 +36,9 @@ export function Navbar({ dashcStats }: NavbarProps) {
             <NavLink href="/creator-wallets" active={pathname === "/creator-wallets"}>
               Creator Wallets
             </NavLink>
+            <NavLink href="/founders-guide" active={pathname === "/founders-guide"}>
+              Founder's Guide
+            </NavLink>
           </nav>
         </div>
       </div>
@@ -50,6 +53,9 @@ export function Navbar({ dashcStats }: NavbarProps) {
           </NavLink>
           <NavLink href="/creator-wallets" active={pathname === "/creator-wallets"}>
             Creator Wallets
+          </NavLink>
+          <NavLink href="/founders-guide" active={pathname === "/founders-guide"}>
+            Founder's Guide
           </NavLink>
         </nav>
       </div>

--- a/components/scroll-progress.tsx
+++ b/components/scroll-progress.tsx
@@ -1,0 +1,26 @@
+"use client";
+import { useEffect, useState } from "react";
+
+export default function ScrollProgress() {
+  const [progress, setProgress] = useState(0);
+  useEffect(() => {
+    const update = () => {
+      const total = document.documentElement.scrollHeight - window.innerHeight;
+      const scroll = window.scrollY;
+      const pct = total > 0 ? (scroll / total) * 100 : 0;
+      setProgress(pct);
+    };
+    update();
+    window.addEventListener("scroll", update);
+    window.addEventListener("resize", update);
+    return () => {
+      window.removeEventListener("scroll", update);
+      window.removeEventListener("resize", update);
+    };
+  }, []);
+  return (
+    <div className="fixed top-0 left-0 w-full h-1 bg-dashGreen-light z-40">
+      <div className="h-full bg-dashYellow" style={{ width: `${progress}%` }} />
+    </div>
+  );
+}

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -1,0 +1,24 @@
+"use client";
+import { useTheme } from "next-themes";
+import { Sun, Moon } from "lucide-react";
+import { useEffect, useState } from "react";
+
+export default function ThemeToggle({ className = "" }: { className?: string }) {
+  const { theme, setTheme, resolvedTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+  const current = mounted ? resolvedTheme : theme;
+  return (
+    <button
+      aria-label="Toggle theme"
+      onClick={() => setTheme(current === "dark" ? "light" : "dark")}
+      className={`p-2 rounded-md border border-dashGreen-light hover:bg-dashGreen-light ${className}`}
+    >
+      {current === "dark" ? (
+        <Sun className="h-5 w-5" />
+      ) : (
+        <Moon className="h-5 w-5" />
+      )}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- add new Founder's Guide route that fetches Google Doc HTML using ENV var
- create FoundersGuide component with ToC, theme toggle, and scroll progress bar
- add theme toggle and progress utilities
- expose Founder's Guide in the navbar

## Testing
- `npm test` *(fails: 0 tests)*
- `npm run lint` *(fails: next not found because dependencies are not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683abac9ec80832c83dc51a825f082b7