### PR TITLE
Fix token research columns

### DIFF
--- a/components/token-table.tsx
+++ b/components/token-table.tsx
@@ -511,8 +511,7 @@ export default function TokenTable({ data }: { data: PaginatedTokenResponse | To
                       </td>
                       {canonicalChecklist.map(label => {
                         const raw = (token as any)[label]
-                        const val = raw !== undefined && raw !== '' ? valueToScore(raw, (gradeMaps as any)[label]) : null
-                        const display = val === 2 ? 'Yes' : val === 1 ? 'No' : '-'
+                        const display = raw !== undefined && raw !== '' ? raw : '-'
                         return (
                           <td key={label} className="py-3 px-4">{display}</td>
                         )


### PR DESCRIPTION
## Summary
- show raw research values from Google sheet in the token table

## Testing
- `npm test`
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683b49c6bff0832c9183c798a3f1c92a