### PR TITLE
Use env variable for Sheets API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ The cache admin interface is available at `/admin/cache`. This interface allows 
 - `KV_REST_API_TOKEN`: Your Upstash Redis API token
 - `ENABLE_DUNE_API`: Set to `true` to enable real Dune API calls (default: `false`)
 - `VERCEL_ENV`: Automatically set by Vercel to indicate the environment
+- `GOOGLE_SHEETS_API_KEY`: Google Sheets API key used for research data
 
 ## Cache Keys
 

--- a/app/actions/googlesheet-action.ts
+++ b/app/actions/googlesheet-action.ts
@@ -5,11 +5,16 @@ interface ResearchScoreData {
 }
 
 export async function fetchTokenResearch(): Promise<ResearchScoreData[]> {
-  const API_KEY = 'AIzaSyC8QxJez_UTHUJS7vFj1J3Sje0CWS9tXyk';
+  const API_KEY = process.env.GOOGLE_SHEETS_API_KEY;
   const SHEET_ID = '1Nra5QH-JFAsDaTYSyu-KocjbkZ0MATzJ4R-rUt-gLe0';
   const SHEET_NAME = 'Dashcoin Scoring';
   const RANGE = `${SHEET_NAME}!A1:T200`;
   const url = `https://sheets.googleapis.com/v4/spreadsheets/${SHEET_ID}/values/${RANGE}?key=${API_KEY}`;
+
+  if (!API_KEY) {
+    console.error('GOOGLE_SHEETS_API_KEY is not set');
+    return [];
+  }
 
   try {
     const response = await fetch(url);
@@ -73,11 +78,16 @@ interface WalletLinkData {
 }
 
 export async function fetchCreatorWalletLinks(): Promise<WalletLinkData[]> {
-  const API_KEY = 'AIzaSyC8QxJez_UTHUJS7vFj1J3Sje0CWS9tXyk'
+  const API_KEY = process.env.GOOGLE_SHEETS_API_KEY
   const SHEET_ID = '1Nra5QH-JFAsDaTYSyu-KocjbkZ0MATzJ4R-rUt-gLe0'
   const SHEET_NAME = 'Dashcoin Scoring'
   const RANGE = `${SHEET_NAME}!A1:T200`
   const url = `https://sheets.googleapis.com/v4/spreadsheets/${SHEET_ID}/values/${RANGE}?key=${API_KEY}`
+
+  if (!API_KEY) {
+    console.error('GOOGLE_SHEETS_API_KEY is not set')
+    return []
+  }
 
   try {
     const response = await fetch(url)


### PR DESCRIPTION
## Summary
- replace hard coded Google Sheets API key with `process.env.GOOGLE_SHEETS_API_KEY`
- handle missing API key in token detail page and actions
- expose `GOOGLE_SHEETS_API_KEY` setup in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683b775cdb48832c82641b071fc57cc0