### PR TITLE
Add research filters to Top Tokens table

### DIFF
--- a/data/research-filter-options.ts
+++ b/data/research-filter-options.ts
@@ -1,0 +1,35 @@
+export const researchFilterOptions: Record<string, string[]> = {
+  "Team Doxxed": ["Legal Names", "Pseudonymous", "Unknown"],
+  "Twitter Activity Level": ["High", "Medium", "Low", "Unknown"],
+  "Time Commitment": [
+    "Full-time (≥ 35 hrs/wk)",
+    "Part-time / side-project",
+    "Unknown",
+    "Abandoned",
+  ],
+  "Prior Founder Experience": [
+    "Two or more prior startups",
+    "One prior startup",
+    "None",
+    "Unknown",
+  ],
+  "Product Maturity": [
+    "Revenue-positive / paying customers",
+    "Live MVP",
+    "Prototype / pre-alpha",
+    "Unknown",
+  ],
+  "Funding Status": ["Venture Backed", "Angel Investors", "Bootstrapped", "Unknown"],
+  "Token-Product Integration Depth": [
+    "Fully live",
+    "Concept only (white-paper / roadmap)",
+    "None",
+    "Unknown",
+  ],
+  "Social Reach & Engagement Index": [
+    "High ( ≥ 20 k followers )",
+    "Medium ( 5 k – 20 k followers )",
+    "Low ( < 5 k followers )",
+    "Unknown",
+  ],
+};


### PR DESCRIPTION
## Summary
- add filter options for research columns
- update token table to support multiselect filters with URL persistence

## Testing
- `npm test`
- `./setup.sh` *(fails: next not found because packages are missing)*

------
https://chatgpt.com/codex/tasks/task_e_683bd214a340832ca3fdb7356b524e24