### PR TITLE
UI polish for research dashboard

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -228,7 +228,7 @@ export default async function Home() {
         }}
       />
 
-      <main className="container mx-auto px-4 py-4 space-y-6">
+      <main className="container mx-auto px-4 py-4 space-y-4">
 
         {/* Charts */}
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mt-0">
@@ -253,7 +253,7 @@ export default async function Home() {
         </div>
 
         {/* Token Table */}
-        <div className="mt-4">
+        <div className="mt-2">
           <h2 className="dashcoin-text text-3xl text-dashYellow mb-4">
             Top Tokens by Market Cap
           </h2>

--- a/components/market-cap-chart.tsx
+++ b/components/market-cap-chart.tsx
@@ -98,8 +98,10 @@ export function MarketCapChart({ data }: MarketCapChartProps) {
         },
         plugins: {
           legend: {
+            position: "bottom",
             labels: {
               color: dashYellowLight,
+              boxWidth: 12,
             },
           },
           tooltip: {
@@ -150,7 +152,7 @@ export function MarketCapChart({ data }: MarketCapChartProps) {
         <DashcoinCardTitle>Market Cap & Holders Over Time</DashcoinCardTitle>
       </DashcoinCardHeader>
       <DashcoinCardContent>
-        <div className="h-48 bg-[#13131A]">
+        <div className="h-64 bg-neutral-900 rounded-lg">
           <canvas ref={chartRef} />
         </div>
       </DashcoinCardContent>

--- a/components/market-cap-pie.tsx
+++ b/components/market-cap-pie.tsx
@@ -120,7 +120,7 @@ export function MarketCapPie({ data }: MarketCapPieProps) {
         <DashcoinCardTitle>Market Cap Distribution</DashcoinCardTitle>
       </DashcoinCardHeader>
       <DashcoinCardContent>
-        <div className="h-48 bg-[#13131A]">
+        <div className="h-64 bg-neutral-900 rounded-lg">
           <canvas ref={chartRef} />
         </div>
       </DashcoinCardContent>

--- a/components/token-table.tsx
+++ b/components/token-table.tsx
@@ -4,7 +4,29 @@ import { useState, useEffect, useRef } from "react"
 import Link from "next/link"
 import { formatCurrency0 } from "@/lib/utils"
 import { DashcoinCard } from "@/components/ui/dashcoin-card"
-import { ChevronDown, ChevronUp, Search, Loader2, FileSearch, Filter } from "lucide-react"
+import {
+  ChevronDown,
+  ChevronUp,
+  Search,
+  Loader2,
+  FileSearch,
+  Filter,
+  FlaskConical,
+  Twitter,
+  Users,
+  User,
+  Clock,
+  Medal,
+  Package,
+  Layers,
+  TrendingUp,
+} from "lucide-react"
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+  TooltipProvider,
+} from "@/components/ui/tooltip"
 import { fetchPaginatedTokens } from "@/app/actions/dune-actions"
 import type { TokenData, PaginatedTokenResponse } from "@/types/dune"
 import { CopyAddress } from "@/components/copy-address"
@@ -14,6 +36,17 @@ import { fetchTokenResearch } from "@/app/actions/googlesheet-action"
 import { canonicalChecklist } from "@/components/founders-edge-checklist"
 import { researchFilterOptions } from "@/data/research-filter-options"
 import { useRouter, useSearchParams } from "next/navigation"
+
+const checklistIcons: Record<string, JSX.Element> = {
+  "Team Doxxed": <User className="h-4 w-4" />,
+  "Twitter Activity Level": <Twitter className="h-4 w-4" />,
+  "Time Commitment": <Clock className="h-4 w-4" />,
+  "Prior Founder Experience": <Medal className="h-4 w-4" />,
+  "Product Maturity": <Package className="h-4 w-4" />,
+  "Funding Status": <TrendingUp className="h-4 w-4" />,
+  "Token-Product Integration Depth": <Layers className="h-4 w-4" />,
+  "Social Reach & Engagement Index": <Users className="h-4 w-4" />,
+}
 
 interface ResearchScoreData {
   symbol: string
@@ -414,26 +447,34 @@ export default function TokenTable({ data }: { data: PaginatedTokenResponse | To
                 >
                   <div className="flex items-center gap-1">24h %Gain {renderSortIndicator("change24h")}</div>
                 </th>
-                <th 
+                <th
                   className="text-left py-3 px-4 text-dashYellow cursor-pointer"
                   onClick={() => handleSort("researchScore")}
                 >
                   <div className="flex items-center gap-1">
-                    Research Score {renderSortIndicator("researchScore")}
+                    <FlaskConical className="h-4 w-4" />
+                    {renderSortIndicator("researchScore")}
                   </div>
                 </th>
                 {canonicalChecklist.map(label => (
                   <th key={label} className="relative text-left py-3 px-4 text-dashYellow">
-                    <div className="flex items-center gap-1">
-                      {label}
-                      <Filter
-                        className="h-7 w-7 cursor-pointer"
-                        onClick={e => {
-                          e.stopPropagation()
-                          setOpenChecklistFilter(prev => (prev === label ? null : label))
-                        }}
-                      />
-                    </div>
+                    <TooltipProvider delayDuration={0}>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <div className="flex items-center gap-1 cursor-pointer">
+                            {checklistIcons[label]}
+                          </div>
+                        </TooltipTrigger>
+                        <TooltipContent>{label}</TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                    <Filter
+                      className="h-5 w-5 ml-1 cursor-pointer inline"
+                      onClick={e => {
+                        e.stopPropagation()
+                        setOpenChecklistFilter(prev => (prev === label ? null : label))
+                      }}
+                    />
                     {openChecklistFilter === label && (
                       <div
                         ref={el => (checklistRefs.current[label] = el)}
@@ -493,7 +534,8 @@ export default function TokenTable({ data }: { data: PaginatedTokenResponse | To
                   return (
                     <tr
                       key={index}
-                      className="border-b border-dashGreen-light hover:bg-dashGreen-card dark:hover:bg-dashGreen-cardDark"
+                      className="border-b border-dashGreen-light odd:bg-neutral-800 even:bg-neutral-900 hover:bg-neutral-700 cursor-pointer"
+                      onClick={() => router.push(`/tokendetail/${tokenSymbol}`)}
                     >
                       <td className="py-3 px-4">
                         <Link href={`/tokendetail/${tokenSymbol}`} className="hover:text-dashYellow">
@@ -503,19 +545,19 @@ export default function TokenTable({ data }: { data: PaginatedTokenResponse | To
                               <CopyAddress
                                 address={tokenAddress}
                                 showBackground={false}
-                                className="text-xs opacity-80 hover:opacity-100"
+                                className="hidden md:inline text-xs opacity-70 hover:opacity-100"
                               />
                             )}
                           </div>
                         </Link>
                       </td>
                       <td className="py-3 px-4">
-                        <div className="flex gap-2">
+                        <div className="flex justify-end">
                           <a
                             href={tokenAddress ? `https://axiom.trade/t/${tokenAddress}/dashc` : "#"}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="px-2 py-1.5 bg-dashYellow text-dashBlack font-medium rounded-md hover:bg-dashYellow-dark transition-colors text-sm flex items-center justify-center min-w-[60px] border border-dashBlack"
+                            className="px-3 py-1.5 bg-blue-600 text-white font-medium rounded-md hover:bg-blue-500 transition-colors text-sm min-w-[72px]"
                           >
                             TRADE
                           </a>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -21,11 +21,11 @@ const config = {
       colors: {
         dashGreen: {
           DEFAULT: "#3a3a3a", // base grey
-          dark: "#1a1a1a", // near black
+          dark: "#1f2937", // deep slate
           light: "#4f4f4f",
           accent: "#656565",
           card: "#2b2b2b",
-          cardDark: "#161616",
+          cardDark: "#1e1e24",
         },
         dashYellow: {
           DEFAULT: "#f5f5f5", // off-white
@@ -36,7 +36,7 @@ const config = {
           DEFAULT: "#ff6666",
           dark: "#cc3333",
         },
-        dashBlack: "#000000",
+        dashBlack: "#27272A",
 
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",


### PR DESCRIPTION
## Summary
- tweak dark palette to use deep slate and charcoal
- modernize token table with zebra rows, hover CTA, and icon headers
- make chart legends clearer and chart areas rounded
- reduce vertical spacing on dashboard page

## Testing
- `npm test`
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683c969f20c8832cbe31574e34f3504f