### PR TITLE
UI polish for research dashboard

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,7 +21,7 @@ import { fetchDexscreenerTokenData } from "./actions/dexscreener-actions";
 import { formatCurrency } from "@/lib/utils";
 import EnvSetup from "./env-setup";
 import { Suspense } from "react";
-import TokenTable from "@/components/token-table";
+import TokenCardList from "@/components/token-card-list";
 import { Navbar } from "@/components/navbar";
 import { Twitter } from "lucide-react";
 
@@ -61,7 +61,7 @@ const MarketCapPieWrapper = async ({
   }
 };
 
-const TokenTableWrapper = async ({
+const TokenCardListWrapper = async ({
   tokenDataPromise,
 }: {
   tokenDataPromise: Promise<any>;
@@ -69,7 +69,7 @@ const TokenTableWrapper = async ({
   try {
     const tokenData = await tokenDataPromise;
     return (
-      <TokenTable
+      <TokenCardList
         data={
           tokenData || {
             tokens: [],
@@ -82,7 +82,7 @@ const TokenTableWrapper = async ({
       />
     );
   } catch (error) {
-    console.error("Error in TokenTableWrapper:", error);
+    console.error("Error in TokenCardListWrapper:", error);
     return (
       <DashcoinCard className="p-8 flex items-center justify-center">
         <p className="text-center">Error loading token data</p>
@@ -228,7 +228,7 @@ export default async function Home() {
         }}
       />
 
-      <main className="container mx-auto px-4 py-4 space-y-6">
+      <main className="container mx-auto px-4 py-4 space-y-4">
 
         {/* Charts */}
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mt-0">
@@ -253,7 +253,7 @@ export default async function Home() {
         </div>
 
         {/* Token Table */}
-        <div className="mt-4">
+        <div className="mt-2">
           <h2 className="dashcoin-text text-3xl text-dashYellow mb-4">
             Top Tokens by Market Cap
           </h2>
@@ -267,7 +267,7 @@ export default async function Home() {
               </DashcoinCard>
             }
           >
-            <TokenTableWrapper tokenDataPromise={tokenDataPromise} />
+            <TokenCardListWrapper tokenDataPromise={tokenDataPromise} />
           </Suspense>
         </div>
 

--- a/components/market-cap-chart.tsx
+++ b/components/market-cap-chart.tsx
@@ -98,8 +98,10 @@ export function MarketCapChart({ data }: MarketCapChartProps) {
         },
         plugins: {
           legend: {
+            position: "bottom",
             labels: {
               color: dashYellowLight,
+              boxWidth: 12,
             },
           },
           tooltip: {
@@ -150,7 +152,7 @@ export function MarketCapChart({ data }: MarketCapChartProps) {
         <DashcoinCardTitle>Market Cap & Holders Over Time</DashcoinCardTitle>
       </DashcoinCardHeader>
       <DashcoinCardContent>
-        <div className="h-48 bg-[#13131A]">
+        <div className="h-64 bg-neutral-900 rounded-lg">
           <canvas ref={chartRef} />
         </div>
       </DashcoinCardContent>

--- a/components/market-cap-pie.tsx
+++ b/components/market-cap-pie.tsx
@@ -120,7 +120,7 @@ export function MarketCapPie({ data }: MarketCapPieProps) {
         <DashcoinCardTitle>Market Cap Distribution</DashcoinCardTitle>
       </DashcoinCardHeader>
       <DashcoinCardContent>
-        <div className="h-48 bg-[#13131A]">
+        <div className="h-64 bg-neutral-900 rounded-lg">
           <canvas ref={chartRef} />
         </div>
       </DashcoinCardContent>

--- a/components/token-card-list.tsx
+++ b/components/token-card-list.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { DashcoinCard } from "@/components/ui/dashcoin-card";
+import { TokenCard } from "@/components/token-card";
+import { fetchTokenResearch } from "@/app/actions/googlesheet-action";
+import type { TokenData, PaginatedTokenResponse } from "@/types/dune";
+import { fetchPaginatedTokens } from "@/app/actions/dune-actions";
+import { Input } from "@/components/ui/input";
+
+interface ResearchScoreData {
+  symbol: string;
+  score: number | null;
+  [key: string]: any;
+}
+
+export default function TokenCardList({ data }: { data: PaginatedTokenResponse | TokenData[] }) {
+  const initialData = Array.isArray(data)
+    ? { tokens: data, page: 1, pageSize: 10, totalTokens: data.length, totalPages: Math.ceil(data.length / 10) }
+    : data;
+
+  const [searchTerm, setSearchTerm] = useState("");
+  const [sortField, setSortField] = useState("marketCap");
+  const [sortDirection, setSortDirection] = useState("desc");
+  const [tokens, setTokens] = useState<TokenData[]>(initialData.tokens || []);
+  const [researchScores, setResearchScores] = useState<ResearchScoreData[]>([]);
+
+  useEffect(() => {
+    const getResearchScores = async () => {
+      try {
+        const scores = await fetchTokenResearch();
+        setResearchScores(scores);
+      } catch (err) {
+        console.error("Error fetching research scores", err);
+      }
+    };
+    getResearchScores();
+  }, []);
+
+  useEffect(() => {
+    async function fetchPage() {
+      try {
+        const resp = await fetchPaginatedTokens(1, 20, sortField, sortDirection, searchTerm);
+        setTokens(resp.tokens);
+      } catch (err) {
+        console.error("error fetching tokens", err);
+      }
+    }
+    fetchPage();
+  }, [searchTerm, sortField, sortDirection]);
+
+  const getResearch = (symbol: string) => researchScores.find(r => r.symbol.toUpperCase() === symbol.toUpperCase()) || null;
+
+  return (
+    <div>
+      <div className="flex flex-col sm:flex-row gap-2 mb-4">
+        <Input
+          placeholder="Search tokens"
+          value={searchTerm}
+          onChange={e => setSearchTerm(e.target.value)}
+          className="flex-1"
+        />
+        <select
+          className="bg-neutral-800 border border-neutral-600 rounded-md px-2 text-sm"
+          value={sortField}
+          onChange={e => setSortField(e.target.value)}
+        >
+          <option value="marketCap">Market Cap</option>
+          <option value="researchScore">Research Score</option>
+        </select>
+        <select
+          className="bg-neutral-800 border border-neutral-600 rounded-md px-2 text-sm"
+          value={sortDirection}
+          onChange={e => setSortDirection(e.target.value)}
+        >
+          <option value="desc">Desc</option>
+          <option value="asc">Asc</option>
+        </select>
+      </div>
+      {tokens.length === 0 ? (
+        <DashcoinCard className="p-8 text-center">No tokens found</DashcoinCard>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {tokens.map(token => (
+            <TokenCard key={token.symbol} token={token} research={getResearch(token.symbol || "")} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/components/token-card.tsx
+++ b/components/token-card.tsx
@@ -1,0 +1,89 @@
+import { DashcoinCard, DashcoinCardContent, DashcoinCardHeader, DashcoinCardTitle } from "@/components/ui/dashcoin-card";
+import { formatCurrency0 } from "@/lib/utils";
+import { CopyAddress } from "@/components/copy-address";
+import { canonicalChecklist } from "@/components/founders-edge-checklist";
+import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from "@/components/ui/tooltip";
+import { useRouter } from "next/navigation";
+
+interface TokenCardProps {
+  token: any;
+  research: Record<string, any> | null;
+}
+
+function getChecklistColor(value: any) {
+  if (value === "Yes" || value === 2 || value === "High" || value === "Full-time (≥ 35 hrs/wk)" || value === "Two or more prior startups" || value === "Revenue-positive / paying customers" || value === "Venture Backed" || value === "Fully live" || value === "High ( ≥ 20 k followers )") {
+    return "bg-green-600";
+  }
+  if (value === "No" || value === 1) {
+    return "bg-red-600";
+  }
+  return "bg-gray-600";
+}
+
+export function TokenCard({ token, research }: TokenCardProps) {
+  const router = useRouter();
+  const tokenAddress = token?.token || "";
+  const tokenSymbol = token?.symbol || "???";
+  const marketCap = token?.marketCap || 0;
+  const change24h = token?.change24h || 0;
+  const score = research?.score ?? null;
+
+  return (
+    <DashcoinCard className="p-4 flex flex-col justify-between bg-neutral-800 hover:bg-neutral-700 transition-colors">
+      <DashcoinCardHeader className="flex justify-between items-start">
+        <div>
+          <h3 className="text-lg font-semibold text-dashYellow">{tokenSymbol}</h3>
+          {tokenAddress && (
+            <CopyAddress address={tokenAddress} showBackground={false} className="text-xs opacity-70" />
+          )}
+        </div>
+        {score !== null && (
+          <span className="rounded-full bg-neutral-700 px-2 py-0.5 text-sm font-semibold">
+            {Number(score).toFixed(1)}
+          </span>
+        )}
+      </DashcoinCardHeader>
+      <DashcoinCardContent className="flex-1 flex flex-col justify-between">
+        <div className="mt-2">
+          <p className="text-sm opacity-70">Market Cap</p>
+          <p className="text-lg font-semibold">{formatCurrency0(marketCap)}</p>
+          <p className={change24h >= 0 ? "text-green-400 text-sm" : "text-red-400 text-sm"}>
+            {change24h >= 0 ? "▲" : "▼"}{Math.abs(change24h).toFixed(2)}%
+          </p>
+        </div>
+        <div className="mt-3 grid grid-cols-4 gap-1">
+          {canonicalChecklist.map((label) => {
+            const val = research ? research[label] : null;
+            return (
+              <TooltipProvider key={label} delayDuration={0}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className={`h-2 w-2 rounded-full ${getChecklistColor(val)}`}></span>
+                  </TooltipTrigger>
+                  <TooltipContent>{label}: {val ?? "?"}</TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            );
+          })}
+        </div>
+        <div className="mt-4 flex justify-between items-center">
+          <a
+            href={tokenAddress ? `https://axiom.trade/t/${tokenAddress}/dashc` : "#"}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="px-3 py-1.5 bg-blue-600 text-white text-sm rounded-md hover:bg-blue-500"
+          >
+            TRADE
+          </a>
+          <button
+            onClick={() => router.push(`/tokendetail/${tokenSymbol}`)}
+            className="text-sm text-dashYellow hover:text-dashYellow-dark"
+          >
+            Details
+          </button>
+        </div>
+      </DashcoinCardContent>
+    </DashcoinCard>
+  );
+}
+

--- a/components/token-table.tsx
+++ b/components/token-table.tsx
@@ -4,7 +4,29 @@ import { useState, useEffect, useRef } from "react"
 import Link from "next/link"
 import { formatCurrency0 } from "@/lib/utils"
 import { DashcoinCard } from "@/components/ui/dashcoin-card"
-import { ChevronDown, ChevronUp, Search, Loader2, FileSearch, Filter } from "lucide-react"
+import {
+  ChevronDown,
+  ChevronUp,
+  Search,
+  Loader2,
+  FileSearch,
+  Filter,
+  FlaskConical,
+  Twitter,
+  Users,
+  User,
+  Clock,
+  Medal,
+  Package,
+  Layers,
+  TrendingUp,
+} from "lucide-react"
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+  TooltipProvider,
+} from "@/components/ui/tooltip"
 import { fetchPaginatedTokens } from "@/app/actions/dune-actions"
 import type { TokenData, PaginatedTokenResponse } from "@/types/dune"
 import { CopyAddress } from "@/components/copy-address"
@@ -14,6 +36,17 @@ import { fetchTokenResearch } from "@/app/actions/googlesheet-action"
 import { canonicalChecklist } from "@/components/founders-edge-checklist"
 import { researchFilterOptions } from "@/data/research-filter-options"
 import { useRouter, useSearchParams } from "next/navigation"
+
+const checklistIcons: Record<string, JSX.Element> = {
+  "Team Doxxed": <User className="h-4 w-4" />,
+  "Twitter Activity Level": <Twitter className="h-4 w-4" />,
+  "Time Commitment": <Clock className="h-4 w-4" />,
+  "Prior Founder Experience": <Medal className="h-4 w-4" />,
+  "Product Maturity": <Package className="h-4 w-4" />,
+  "Funding Status": <TrendingUp className="h-4 w-4" />,
+  "Token-Product Integration Depth": <Layers className="h-4 w-4" />,
+  "Social Reach & Engagement Index": <Users className="h-4 w-4" />,
+}
 
 interface ResearchScoreData {
   symbol: string
@@ -414,26 +447,34 @@ export default function TokenTable({ data }: { data: PaginatedTokenResponse | To
                 >
                   <div className="flex items-center gap-1">24h %Gain {renderSortIndicator("change24h")}</div>
                 </th>
-                <th 
+                <th
                   className="text-left py-3 px-4 text-dashYellow cursor-pointer"
                   onClick={() => handleSort("researchScore")}
                 >
                   <div className="flex items-center gap-1">
-                    Research Score {renderSortIndicator("researchScore")}
+                    <FlaskConical className="h-4 w-4" />
+                    {renderSortIndicator("researchScore")}
                   </div>
                 </th>
                 {canonicalChecklist.map(label => (
                   <th key={label} className="relative text-left py-3 px-4 text-dashYellow">
-                    <div className="flex items-center gap-1">
-                      {label}
-                      <Filter
-                        className="h-7 w-7 cursor-pointer"
-                        onClick={e => {
-                          e.stopPropagation()
-                          setOpenChecklistFilter(prev => (prev === label ? null : label))
-                        }}
-                      />
-                    </div>
+                    <TooltipProvider delayDuration={0}>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <div className="flex items-center gap-1 cursor-pointer">
+                            {checklistIcons[label]}
+                          </div>
+                        </TooltipTrigger>
+                        <TooltipContent>{label}</TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                    <Filter
+                      className="h-5 w-5 ml-1 cursor-pointer inline"
+                      onClick={e => {
+                        e.stopPropagation()
+                        setOpenChecklistFilter(prev => (prev === label ? null : label))
+                      }}
+                    />
                     {openChecklistFilter === label && (
                       <div
                         ref={el => (checklistRefs.current[label] = el)}
@@ -493,7 +534,8 @@ export default function TokenTable({ data }: { data: PaginatedTokenResponse | To
                   return (
                     <tr
                       key={index}
-                      className="border-b border-dashGreen-light hover:bg-dashGreen-card dark:hover:bg-dashGreen-cardDark"
+                      className="border-b border-dashGreen-light odd:bg-neutral-800 even:bg-neutral-900 hover:bg-neutral-700 cursor-pointer"
+                      onClick={() => router.push(`/tokendetail/${tokenSymbol}`)}
                     >
                       <td className="py-3 px-4">
                         <Link href={`/tokendetail/${tokenSymbol}`} className="hover:text-dashYellow">
@@ -503,19 +545,19 @@ export default function TokenTable({ data }: { data: PaginatedTokenResponse | To
                               <CopyAddress
                                 address={tokenAddress}
                                 showBackground={false}
-                                className="text-xs opacity-80 hover:opacity-100"
+                                className="hidden md:inline text-xs opacity-70 hover:opacity-100"
                               />
                             )}
                           </div>
                         </Link>
                       </td>
                       <td className="py-3 px-4">
-                        <div className="flex gap-2">
+                        <div className="flex justify-end">
                           <a
                             href={tokenAddress ? `https://axiom.trade/t/${tokenAddress}/dashc` : "#"}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="px-2 py-1.5 bg-dashYellow text-dashBlack font-medium rounded-md hover:bg-dashYellow-dark transition-colors text-sm flex items-center justify-center min-w-[60px] border border-dashBlack"
+                            className="px-3 py-1.5 bg-blue-600 text-white font-medium rounded-md hover:bg-blue-500 transition-colors text-sm min-w-[72px]"
                           >
                             TRADE
                           </a>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -21,11 +21,11 @@ const config = {
       colors: {
         dashGreen: {
           DEFAULT: "#3a3a3a", // base grey
-          dark: "#1a1a1a", // near black
+          dark: "#1f2937", // deep slate
           light: "#4f4f4f",
           accent: "#656565",
           card: "#2b2b2b",
-          cardDark: "#161616",
+          cardDark: "#1e1e24",
         },
         dashYellow: {
           DEFAULT: "#f5f5f5", // off-white
@@ -36,7 +36,7 @@ const config = {
           DEFAULT: "#ff6666",
           dark: "#cc3333",
         },
-        dashBlack: "#000000",
+        dashBlack: "#27272A",
 
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",


### PR DESCRIPTION
## Summary
- tweak dark palette to use deep slate and charcoal
- modernize token table with zebra rows, hover CTA, and icon headers
- make chart legends clearer and chart areas rounded
- reduce vertical spacing on dashboard page
- add token card layout to replace table view

## Testing
- `npm test`
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683c969f20c8832cbe31574e34f3504f