### PR TITLE
Move charts to bottom of overview page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -231,27 +231,6 @@ export default async function Home() {
 
       <main className="container mx-auto px-4 py-4 space-y-4">
 
-        {/* Charts */}
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mt-0">
-          <Suspense
-            fallback={
-              <DashcoinCard className="h-48 flex items-center justify-center">
-                <p>Loading chart...</p>
-              </DashcoinCard>
-            }
-          >
-            <MarketCapChartWrapper marketCapTimeDataPromise={marketCapTimeDataPromise} />
-          </Suspense>
-          <Suspense
-            fallback={
-              <DashcoinCard className="h-48 flex items-center justify-center">
-                <p>Loading chart...</p>
-              </DashcoinCard>
-            }
-          >
-            <MarketCapPieWrapper tokenMarketCapsPromise={tokenMarketCapsPromise} />
-          </Suspense>
-        </div>
 
         {/* Token Table */}
         <div className="mt-2">
@@ -306,6 +285,28 @@ export default async function Home() {
               </div>
             </DashcoinCardContent>
           </DashcoinCard>
+        </div>
+
+        {/* Charts */}
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mt-0">
+          <Suspense
+            fallback={
+              <DashcoinCard className="h-48 flex items-center justify-center">
+                <p>Loading chart...</p>
+              </DashcoinCard>
+            }
+          >
+            <MarketCapChartWrapper marketCapTimeDataPromise={marketCapTimeDataPromise} />
+          </Suspense>
+          <Suspense
+            fallback={
+              <DashcoinCard className="h-48 flex items-center justify-center">
+                <p>Loading chart...</p>
+              </DashcoinCard>
+            }
+          >
+            <MarketCapPieWrapper tokenMarketCapsPromise={tokenMarketCapsPromise} />
+          </Suspense>
         </div>
 
       </main>


### PR DESCRIPTION
## Summary
- show market data table and stats first
- render overview charts at end of page

## Testing
- `npm test`
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683cb6437480832ca4c35284d19cfd5a