### PR TITLE
Link token names to detail page

### DIFF
--- a/components/token-card.tsx
+++ b/components/token-card.tsx
@@ -40,10 +40,12 @@ export function TokenCard({ token, researchScore }: TokenCardProps) {
   return (
     <DashcoinCard className="p-4 flex flex-col gap-3">
       <div className="flex justify-between items-start">
-        <div>
-          <p className="text-lg font-bold text-dashYellow">{tokenSymbol}</p>
-          {token.name && <p className="text-sm opacity-70">{token.name}</p>}
-        </div>
+        <Link href={`/tokendetail/${tokenSymbol}`} className="hover:text-dashYellow">
+          <div>
+            <p className="text-lg font-bold text-dashYellow">{tokenSymbol}</p>
+            {token.name && <p className="text-sm opacity-70">{token.name}</p>}
+          </div>
+        </Link>
         {researchScore !== null && (
           <span className="px-2 py-1 rounded-full bg-blue-600 text-sm font-medium">
             {researchScore.toFixed(1)}


### PR DESCRIPTION
## Summary
- make the token name on each token card link to its token detail page

## Testing
- `npm test`
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683cb88aaad4832c8e86f08dd45bae94