### PR TITLE
Improve token grid and card style

### DIFF
--- a/components/token-card-list.tsx
+++ b/components/token-card-list.tsx
@@ -77,7 +77,10 @@ export default function TokenCardList({ data }: { data: PaginatedTokenResponse |
   }
 
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+    <div
+      className="grid gap-4"
+      style={{ gridTemplateColumns: "repeat(auto-fill, minmax(300px, 1fr))" }}
+    >
       {tokensWithData.map((token, idx) => {
         const researchScore = token.score ?? null
         return <TokenCard key={idx} token={token} researchScore={researchScore} />

--- a/components/token-card.tsx
+++ b/components/token-card.tsx
@@ -38,7 +38,7 @@ export function TokenCard({ token, researchScore }: TokenCardProps) {
   const change24h = token.change24h || 0
 
   return (
-    <DashcoinCard className="p-4 flex flex-col gap-3">
+    <DashcoinCard className="p-5 flex flex-col gap-4">
       <div className="flex justify-between items-start">
         <Link href={`/tokendetail/${tokenSymbol}`} className="hover:text-dashYellow">
           <div>
@@ -53,14 +53,17 @@ export function TokenCard({ token, researchScore }: TokenCardProps) {
         )}
       </div>
 
-      <div className="flex justify-between text-sm">
-        <div>
-          <p className="opacity-70">Market Cap</p>
-          <p>{formatCurrency0(token.marketCap || 0)}</p>
-        </div>
-        <div className={`text-right ${change24h > 0 ? 'text-green-500' : change24h < 0 ? 'text-red-500' : ''}`}> 
-          <p className="opacity-70">24h %</p>
-          <p>{change24h.toFixed(2)}%</p>
+      <div className="flex items-start justify-between text-sm">
+        <div className="flex items-center gap-3">
+          <div>
+            <p className="opacity-70">Market Cap</p>
+            <p>{formatCurrency0(token.marketCap || 0)}</p>
+          </div>
+          <span className="opacity-50">|</span>
+          <div className={`${change24h > 0 ? 'text-green-500' : change24h < 0 ? 'text-red-500' : ''}`}>
+            <p className="opacity-70">24h %</p>
+            <p>{change24h.toFixed(2)}%</p>
+          </div>
         </div>
       </div>
 
@@ -91,7 +94,7 @@ export function TokenCard({ token, researchScore }: TokenCardProps) {
           href={tokenAddress ? `https://axiom.trade/t/${tokenAddress}/dashc` : '#'}
           target="_blank"
           rel="noopener noreferrer"
-          className="px-3 py-1.5 bg-blue-600 text-white rounded-md text-sm hover:bg-blue-500"
+          className="px-3 py-1.5 bg-blue-600 text-white rounded-md text-sm hover:bg-blue-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 hover:shadow-md"
         >
           TRADE
         </a>

--- a/components/ui/dashcoin-card.tsx
+++ b/components/ui/dashcoin-card.tsx
@@ -2,8 +2,13 @@ import * as React from "react"
 import { cn } from "@/lib/utils"
 
 const DashcoinCard = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("card-with-border p-6 shadow-xl", className)} {...props} />
+  ({ className, style, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn("card-with-border p-6", className)}
+      style={{ boxShadow: "0px 2px 8px rgba(0,0,0,0.15)", ...(style || {}) }}
+      {...props}
+    />
   ),
 )
 DashcoinCard.displayName = "DashcoinCard"


### PR DESCRIPTION
## Summary
- add subtle shadow styling for cards
- make token grid auto-fill responsive
- tweak token card metrics layout and button highlight

## Testing
- `npm test`
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683cbd3a9930832ca3945ca075990dcc