### PR TITLE
Add light/dark theme toggle

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -6,55 +6,61 @@
 
 @layer base {
   :root {
-    --background: 240 16% 9%; /* #13131A */
-    --foreground: 240 25% 92%; /* #E6E6F0 */
+    --background: 0 0% 100%;
+    --foreground: 0 0% 0%;
 
-    --card: 240 17% 13%; /* #1B1B26 */
-    --card-foreground: 240 25% 92%;
+    --card: 0 0% 100%;
+    --card-foreground: 0 0% 0%;
 
-    --popover: 240 17% 13%;
-    --popover-foreground: 240 25% 92%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 0 0% 0%;
 
-    --primary: 240 25% 92%;
-    --primary-foreground: 240 16% 9%;
+    --primary: 0 0% 0%;
+    --primary-foreground: 0 0% 100%;
 
-    --secondary: 240 17% 13%;
-    --secondary-foreground: 240 25% 92%;
+    --secondary: 0 0% 100%;
+    --secondary-foreground: 0 0% 0%;
 
-    --muted: 240 17% 20%;
-    --muted-foreground: 240 9% 66%; /* #A0A0B0 */
+    --muted: 0 0% 96%;
+    --muted-foreground: 0 0% 30%;
 
-    --accent: 33 93% 54%; /* Bitcoin Orange */
-    --accent-foreground: 240 16% 9%;
+    --accent: 33 93% 54%;
+    --accent-foreground: 0 0% 0%;
 
-    --destructive: 359 79% 58%; /* Bright Red */
-    --destructive-foreground: 240 25% 92%;
+    --destructive: 359 79% 58%;
+    --destructive-foreground: 0 0% 100%;
 
-    --border: 240 17% 20%;
-    --input: 240 17% 20%;
-    --ring: 240 25% 92%;
+    --border: 0 0% 89%;
+    --input: 0 0% 89%;
+    --ring: 0 0% 89%;
 
     --radius: 0.75rem;
 
-    --dashcoin-yellow: #E6E6F0;
-    --dashcoin-yellow-dark: #E6E6F0;
-    --dashcoin-yellow-light: #E6E6F0;
-    --dashcoin-green: #13131A;
-    --dashcoin-green-dark: #13131A;
-    --dashcoin-green-light: #1B1B26;
-    --dashcoin-green-accent: #1B1B26;
+    --dashcoin-yellow: #ffffff;
+    --dashcoin-yellow-dark: #f5f5f5;
+    --dashcoin-yellow-light: #f5f5f5;
+    --dashcoin-green: #ffffff;
+    --dashcoin-green-dark: #f5f5f5;
+    --dashcoin-green-light: #e5e5e5;
+    --dashcoin-green-accent: #f0f0f0;
+    --dashcoin-green-card: #ffffff;
+    --dashcoin-green-card-dark: #f5f5f5;
     --dashcoin-black: #000000;
     --dashcoin-red: #E84042;
+    --dashcoin-red-dark: #cc3333;
 
     --dashGreen: var(--dashcoin-green);
     --dashGreen-dark: var(--dashcoin-green-dark);
     --dashGreen-light: var(--dashcoin-green-light);
     --dashGreen-accent: var(--dashcoin-green-accent);
+    --dashGreen-card: var(--dashcoin-green-card);
+    --dashGreen-cardDark: var(--dashcoin-green-card-dark);
     --dashYellow: var(--dashcoin-yellow);
     --dashYellow-dark: var(--dashcoin-yellow-dark);
     --dashYellow-light: var(--dashcoin-yellow-light);
     --dashBlack: var(--dashcoin-black);
     --dashRed: var(--dashcoin-red);
+    --dashRed-dark: var(--dashcoin-red-dark);
   }
 
   body {
@@ -86,6 +92,18 @@
     --border: 240 17% 20%;
     --input: 240 17% 20%;
     --ring: 240 25% 92%;
+    --dashcoin-yellow: #E6E6F0;
+    --dashcoin-yellow-dark: #E6E6F0;
+    --dashcoin-yellow-light: #E6E6F0;
+    --dashcoin-green: #13131A;
+    --dashcoin-green-dark: #13131A;
+    --dashcoin-green-light: #1B1B26;
+    --dashcoin-green-accent: #1B1B26;
+    --dashcoin-green-card: #1B1B26;
+    --dashcoin-green-card-dark: #1e1e24;
+    --dashcoin-black: #000000;
+    --dashcoin-red: #E84042;
+    --dashcoin-red-dark: #cc3333;
   }
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -17,9 +17,9 @@ export default function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <html lang="en" suppressHydrationWarning className="dark">
-      <body className="font-sans bg-dashGreen-dark text-dashYellow-light min-h-screen">
-        <ThemeProvider attribute="class" defaultTheme="dark" enableSystem disableTransitionOnChange>
+    <html lang="en" suppressHydrationWarning>
+      <body className="font-sans bg-white text-black dark:bg-[#111] dark:text-[#f5f5f5] min-h-screen">
+        <ThemeProvider attribute="class" defaultTheme="light" enableSystem disableTransitionOnChange>
           {children}
         </ThemeProvider>
       </body>

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { DashcoinLogo } from "@/components/dashcoin-logo";
 import { DashcStatsBar, DashcStatsBarProps } from "@/components/dashc-stats-bar";
+import { ThemeToggle } from "@/components/theme-toggle";
 
 interface NavbarProps {
   dashcStats?: DashcStatsBarProps;
@@ -40,6 +41,7 @@ export function Navbar({ dashcStats }: NavbarProps) {
               Founder's Guide
             </NavLink>
           </nav>
+          <ThemeToggle />
         </div>
       </div>
       {/* Mobile Navigation */}

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -1,0 +1,28 @@
+"use client"
+
+import { useTheme } from "next-themes"
+import { useEffect, useState } from "react"
+import { Sun, Moon } from "lucide-react"
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme()
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => setMounted(true), [])
+
+  if (!mounted) return null
+
+  const toggleTheme = () => {
+    setTheme(theme === "dark" ? "light" : "dark")
+  }
+
+  return (
+    <button
+      aria-label="Toggle theme"
+      onClick={toggleTheme}
+      className="p-2 rounded-md border border-border bg-background text-foreground hover:bg-muted"
+    >
+      {theme === "dark" ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
+    </button>
+  )
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -20,23 +20,23 @@ const config = {
     extend: {
       colors: {
         dashGreen: {
-          DEFAULT: "#3a3a3a", // base grey
-          dark: "#1f2937", // deep slate
-          light: "#4f4f4f",
-          accent: "#656565",
-          card: "#2b2b2b",
-          cardDark: "#1e1e24",
+          DEFAULT: "hsl(var(--dashGreen))",
+          dark: "hsl(var(--dashGreen-dark))",
+          light: "hsl(var(--dashGreen-light))",
+          accent: "hsl(var(--dashGreen-accent))",
+          card: "hsl(var(--dashGreen-card))",
+          cardDark: "hsl(var(--dashGreen-cardDark))",
         },
         dashYellow: {
-          DEFAULT: "#f5f5f5", // off-white
-          light: "#fafafa",
-          dark: "#e5e5e5",
+          DEFAULT: "hsl(var(--dashYellow))",
+          light: "hsl(var(--dashYellow-light))",
+          dark: "hsl(var(--dashYellow-dark))",
         },
         dashRed: {
-          DEFAULT: "#ff6666",
-          dark: "#cc3333",
+          DEFAULT: "hsl(var(--dashRed))",
+          dark: "hsl(var(--dashRed-dark))",
         },
-        dashBlack: "#27272A",
+        dashBlack: "hsl(var(--dashBlack))",
 
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",


### PR DESCRIPTION
## Summary
- switch Next.js theme provider to default to light
- add a theme toggle component
- show theme toggle in the navbar
- map custom colors to CSS variables in Tailwind config
- define light/dark CSS variables in global styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683d41911710832c9bc92ffd369e40f0