### PR TITLE
Change site font to Avenir Next

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Avenir+Next:wght@400;500;600;700&display=swap');
 
 @tailwind base;
 @tailwind components;
@@ -59,7 +59,7 @@
 
   body {
     @apply bg-background text-foreground font-sans;
-    font-family: 'Inter', sans-serif;
+    font-family: 'Avenir Next', sans-serif;
   }
 
   * {
@@ -203,7 +203,7 @@
 .article {
   background: #1B1B26;
   color: #E6E6F0;
-  font-family: 'Inter', sans-serif;
+  font-family: 'Avenir Next', sans-serif;
   width: 100%;
   max-width: none;
   padding: 2rem;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Avenir+Next:wght@400;500;600;700&display=swap');
 
 @tailwind base;
 @tailwind components;
@@ -6,7 +6,7 @@
 
 /* === GLOBAL BODY STYLES === */
 body {
-  font-family: 'Inter', sans-serif;
+  font-family: 'Avenir Next', sans-serif;
 }
 
 /* === UTILITY CLASSES === */

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -78,7 +78,7 @@ const config = {
         sm: "calc(var(--radius) - 4px)",
       },
       fontFamily: {
-        sans: ["Inter", ...fontFamily.sans],
+        sans: ["Avenir Next", ...fontFamily.sans],
       },
       keyframes: {
         "accordion-down": {


### PR DESCRIPTION
## Summary
- switch Tailwind `fontFamily.sans` to **Avenir Next**
- update global styles in `app/globals.css` and `styles/globals.css` to use **Avenir Next**

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683d447029a0832cbbc0bf5aba965b23