### PR TITLE
Limit grid to 3 columns, enlarge overview fonts

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -253,3 +253,8 @@
   background: transparent !important;
   color: inherit !important;
 }
+
+/* Increase font size on overview page */
+.overview-page * {
+  font-size: 130% !important;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -220,7 +220,7 @@ export default async function Home() {
   }
 
   return (
-    <div className="min-h-screen">
+    <div className="min-h-screen overview-page">
       {/* Use the new Navbar component */}
       <Navbar
         dashcStats={{

--- a/components/token-card-list.tsx
+++ b/components/token-card-list.tsx
@@ -78,8 +78,7 @@ export default function TokenCardList({ data }: { data: PaginatedTokenResponse |
 
   return (
     <div
-      className="grid gap-4"
-      style={{ gridTemplateColumns: "repeat(auto-fill, minmax(300px, 1fr))" }}
+      className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4"
     >
       {tokensWithData.map((token, idx) => {
         const researchScore = token.score ?? null


### PR DESCRIPTION
## Summary
- restrict token cards to a maximum of 3 per row
- enlarge all text on the overview page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683d470c780c832cb31964206f2e9861