### PR TITLE
Change site font to Avenir Next

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+@import url('https://fonts.cdnfonts.com/css/avenir-next');
 
 @tailwind base;
 @tailwind components;
@@ -59,7 +59,7 @@
 
   body {
     @apply bg-background text-foreground font-sans;
-    font-family: 'Inter', sans-serif;
+    font-family: 'Avenir Next', 'Avenir', 'Helvetica Neue', Helvetica, Arial, sans-serif;
   }
 
   * {
@@ -203,7 +203,7 @@
 .article {
   background: #1B1B26;
   color: #E6E6F0;
-  font-family: 'Inter', sans-serif;
+  font-family: 'Avenir Next', 'Avenir', 'Helvetica Neue', Helvetica, Arial, sans-serif;
   width: 100%;
   max-width: none;
   padding: 2rem;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+@import url('https://fonts.cdnfonts.com/css/avenir-next');
 
 @tailwind base;
 @tailwind components;
@@ -6,7 +6,7 @@
 
 /* === GLOBAL BODY STYLES === */
 body {
-  font-family: 'Inter', sans-serif;
+  font-family: 'Avenir Next', 'Avenir', 'Helvetica Neue', Helvetica, Arial, sans-serif;
 }
 
 /* === UTILITY CLASSES === */

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -78,7 +78,14 @@ const config = {
         sm: "calc(var(--radius) - 4px)",
       },
       fontFamily: {
-        sans: ["Inter", ...fontFamily.sans],
+        sans: [
+          "Avenir Next",
+          "Avenir",
+          "Helvetica Neue",
+          "Helvetica",
+          "Arial",
+          ...fontFamily.sans,
+        ],
       },
       keyframes: {
         "accordion-down": {


### PR DESCRIPTION
## Summary
- use Avenir Next import from CDN
- add Avenir Next with fallbacks to global CSS body and article styles
- extend Tailwind `fontFamily.sans` to include Avenir Next and fallbacks

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683d447029a0832cbbc0bf5aba965b23