### PR TITLE
Add search across all tokens with client pagination

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,7 +12,7 @@ import { MarketCapPie } from "@/components/market-cap-pie";
 import {
   fetchMarketCapOverTime,
   fetchMarketStats,
-  fetchPaginatedTokens,
+  fetchAllTokensFromDune,
   fetchTokenMarketCaps,
   fetchTotalMarketCap,
   getTimeUntilNextDuneRefresh,
@@ -115,11 +115,13 @@ export default async function Home() {
     };
   });
 
-  const tokenDataPromise = fetchPaginatedTokens(1, 10, "marketCap", "desc").then(data => {
-    return data;
-  }).catch((error) => {
-    console.error("error.fetching tokens makret cap", error);
-    return {}
+  const tokenDataPromise = fetchAllTokensFromDune()
+    .then(data => {
+      return data;
+    })
+    .catch(error => {
+      console.error("error.fetching tokens makret cap", error);
+      return [];
     });
 
   const marketCapTimeDataPromise = fetchMarketCapOverTime().catch((error) => {


### PR DESCRIPTION
## Summary
- fetch all token data for the homepage
- allow searching across all tokens in `TokenCardList`
- add page size selector and pagination controls

## Testing
- `npm test`
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d42c3d2bc832c8cacb55a72aa4019