### PR TITLE
Add DASHC Alpha Group page with wallet gate

### DIFF
--- a/app/alpha-group/page.tsx
+++ b/app/alpha-group/page.tsx
@@ -1,0 +1,105 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { Navbar } from '@/components/navbar'
+import { DashcoinCard, DashcoinCardHeader, DashcoinCardTitle, DashcoinCardContent } from '@/components/ui/dashcoin-card'
+import { DashcoinButton } from '@/components/ui/dashcoin-button'
+
+const DASHC_MINT = '7gkgsqE2Uip7LUyrqEi8fyLPNSbn7GYu9yFgtxZwYUVa'
+
+export default function AlphaGroupPage() {
+  const [walletAddress, setWalletAddress] = useState<string | null>(null)
+  const [balance, setBalance] = useState<number>(0)
+  const [checking, setChecking] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const connectWallet = async () => {
+    setError(null)
+    try {
+      const provider = (window as any).solana
+      if (!provider || !provider.isPhantom) {
+        setError('Phantom wallet not found')
+        return
+      }
+      const resp = await provider.connect()
+      setWalletAddress(resp.publicKey.toString())
+    } catch (e) {
+      console.error(e)
+      setError('Failed to connect wallet')
+    }
+  }
+
+  useEffect(() => {
+    const fetchBalance = async () => {
+      if (!walletAddress) return
+      setChecking(true)
+      setError(null)
+      try {
+        const response = await fetch('https://api.mainnet-beta.solana.com', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            jsonrpc: '2.0',
+            id: 1,
+            method: 'getTokenAccountsByOwner',
+            params: [walletAddress, { mint: DASHC_MINT }, { encoding: 'jsonParsed' }],
+          }),
+        })
+        const json = await response.json()
+        let amount = 0
+        const value = json?.result?.value
+        if (value && value.length > 0) {
+          amount = Number(value[0].account.data.parsed.info.tokenAmount.uiAmount) || 0
+        }
+        setBalance(amount)
+      } catch (e) {
+        console.error(e)
+        setError('Failed to fetch token balance')
+      } finally {
+        setChecking(false)
+      }
+    }
+    fetchBalance()
+  }, [walletAddress])
+
+  const hasAccess = balance > 0
+  const inviteUrl = '#'
+
+  return (
+    <div className="min-h-screen">
+      <Navbar />
+      <main className="container mx-auto px-4 py-6 flex flex-col items-center gap-6">
+        <DashcoinCard className="max-w-lg w-full text-center">
+          <DashcoinCardHeader>
+            <DashcoinCardTitle>Alpha Group Access</DashcoinCardTitle>
+          </DashcoinCardHeader>
+          <DashcoinCardContent className="space-y-4">
+            {!walletAddress ? (
+              <DashcoinButton onClick={connectWallet}>Connect Wallet</DashcoinButton>
+            ) : (
+              <p className="dashcoin-text break-all">Connected: {walletAddress}</p>
+            )}
+            {walletAddress && (
+              <>
+                {checking && <p>Checking token balance...</p>}
+                {!checking && (
+                  hasAccess ? (
+                    <div className="space-y-2">
+                      <p>Your DASHC Balance: {balance}</p>
+                      <a href={inviteUrl} target="_blank" rel="noopener noreferrer">
+                        <DashcoinButton>Join the Alpha Group</DashcoinButton>
+                      </a>
+                    </div>
+                  ) : (
+                    <p className="text-red-500">You must hold Dashcoin (DASHC) to join the Alpha Group.</p>
+                  )
+                )}
+              </>
+            )}
+            {error && <p className="text-red-500">{error}</p>}
+          </DashcoinCardContent>
+        </DashcoinCard>
+      </main>
+    </div>
+  )
+}

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -36,6 +36,9 @@ export function Navbar({ dashcStats }: NavbarProps) {
             <NavLink href="/creator-wallets" active={pathname === "/creator-wallets"}>
               Creator Wallets
             </NavLink>
+            <NavLink href="/alpha-group" active={pathname === "/alpha-group"}>
+              DASHC Alpha Group
+            </NavLink>
             <NavLink href="https://dashcoin-research.gitbook.io/dashcoin-research" active={false} external>
               Founder's Guide
             </NavLink>
@@ -53,6 +56,9 @@ export function Navbar({ dashcStats }: NavbarProps) {
           </NavLink>
           <NavLink href="/creator-wallets" active={pathname === "/creator-wallets"}>
             Creator Wallets
+          </NavLink>
+          <NavLink href="/alpha-group" active={pathname === "/alpha-group"}>
+            DASHC Alpha Group
           </NavLink>
           <NavLink href="https://dashcoin-research.gitbook.io/dashcoin-research" active={false} external>
             Founder's Guide


### PR DESCRIPTION
## Summary
- add new navigation tab for DASHC Alpha Group
- create /alpha-group gated page that checks Phantom wallet for DASHC tokens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683dea1101e8832cafb25ef72107de39