### PR TITLE
Add token search with pagination

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -12,7 +12,6 @@ import { MarketCapPie } from "@/components/market-cap-pie";
 import {
   fetchMarketCapOverTime,
   fetchMarketStats,
-  fetchPaginatedTokens,
   fetchTokenMarketCaps,
   fetchTotalMarketCap,
   getTimeUntilNextDuneRefresh,
@@ -61,29 +60,12 @@ const MarketCapPieWrapper = async ({
 };
 
 
-const TokenCardListWrapper = async ({
-  tokenDataPromise,
-}: {
-  tokenDataPromise: Promise<any>;
-}) => {
+const TokenSearchListWrapper = async () => {
   try {
-    const tokenData = await tokenDataPromise;
-    const TokenCardList = (await import("@/components/token-card-list")).default;
-    return (
-      <TokenCardList
-        data={
-          tokenData || {
-            tokens: [],
-            page: 1,
-            pageSize: 10,
-            totalTokens: 0,
-            totalPages: 1,
-          }
-        }
-      />
-    );
+    const TokenSearchList = (await import("@/components/token-search-list")).default;
+    return <TokenSearchList />;
   } catch (error) {
-    console.error("Error in TokenCardListWrapper:", error);
+    console.error("Error loading TokenSearchList:", error);
     return (
       <DashcoinCard className="p-8 flex items-center justify-center">
         <p className="text-center">Error loading token data</p>
@@ -114,13 +96,6 @@ export default async function Home() {
       coinLaunches: 0,
     };
   });
-
-  const tokenDataPromise = fetchPaginatedTokens(1, 10, "marketCap", "desc").then(data => {
-    return data;
-  }).catch((error) => {
-    console.error("error.fetching tokens makret cap", error);
-    return {}
-    });
 
   const marketCapTimeDataPromise = fetchMarketCapOverTime().catch((error) => {
     console.error("Error fetching market cap over time:", error);
@@ -257,7 +232,7 @@ export default async function Home() {
               </DashcoinCard>
             }
           >
-            <TokenCardListWrapper tokenDataPromise={tokenDataPromise} />
+            <TokenSearchListWrapper />
           </Suspense>
         </div>
 

--- a/components/token-search-list.tsx
+++ b/components/token-search-list.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useState, useEffect, useMemo } from "react";
+import type { TokenData } from "@/types/dune";
+import { TokenCard } from "./token-card";
+import { DashcoinCard } from "@/components/ui/dashcoin-card";
+import { Loader2 } from "lucide-react";
+
+export default function TokenSearchList() {
+  const [tokens, setTokens] = useState<TokenData[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [searchTerm, setSearchTerm] = useState("");
+  const [pageSize, setPageSize] = useState(10);
+  const [currentPage, setCurrentPage] = useState(1);
+
+  useEffect(() => {
+    async function loadTokens() {
+      try {
+        const res = await fetch("/api/tokens");
+        const data = await res.json();
+        setTokens(data || []);
+      } catch (err) {
+        console.error("Error fetching tokens", err);
+      } finally {
+        setLoading(false);
+      }
+    }
+    loadTokens();
+  }, []);
+
+  const filteredTokens = useMemo(() => {
+    if (!searchTerm.trim()) return tokens;
+    const term = searchTerm.toLowerCase();
+    return tokens.filter(t => {
+      return (
+        (t.symbol && t.symbol.toLowerCase().includes(term)) ||
+        (t.name && t.name.toLowerCase().includes(term)) ||
+        (t.description && t.description.toLowerCase().includes(term))
+      );
+    });
+  }, [tokens, searchTerm]);
+
+  const totalPages = Math.max(1, Math.ceil(filteredTokens.length / pageSize));
+
+  const paginatedTokens = useMemo(() => {
+    const start = (currentPage - 1) * pageSize;
+    return filteredTokens.slice(start, start + pageSize);
+  }, [filteredTokens, currentPage, pageSize]);
+
+  useEffect(() => {
+    if (currentPage > totalPages) {
+      setCurrentPage(totalPages);
+    }
+  }, [totalPages, currentPage]);
+
+  const handlePageChange = (page: number) => {
+    if (page < 1 || page > totalPages) return;
+    setCurrentPage(page);
+  };
+
+  if (loading) {
+    return (
+      <DashcoinCard className="p-8 flex items-center justify-center">
+        <Loader2 className="animate-spin h-5 w-5" />
+      </DashcoinCard>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col sm:flex-row gap-4 mb-4">
+        <input
+          type="text"
+          placeholder="Search tokens..."
+          value={searchTerm}
+          onChange={e => {
+            setSearchTerm(e.target.value);
+            setCurrentPage(1);
+          }}
+          className="flex-grow px-3 py-2 bg-dashGreen-dark border border-dashBlack rounded-md text-dashYellow-light focus:outline-none"
+        />
+        <select
+          value={pageSize}
+          onChange={e => {
+            setPageSize(Number(e.target.value));
+            setCurrentPage(1);
+          }}
+          className="px-3 py-2 bg-dashGreen-dark border border-dashBlack rounded-md text-dashYellow-light focus:outline-none"
+        >
+          <option value={10}>10 per page</option>
+          <option value={20}>20 per page</option>
+          <option value={50}>50 per page</option>
+        </select>
+      </div>
+
+      {paginatedTokens.length === 0 ? (
+        <DashcoinCard className="p-8 text-center">No tokens found.</DashcoinCard>
+      ) : (
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+          {paginatedTokens.map((token, idx) => (
+            <TokenCard key={idx} token={token} researchScore={null} />
+          ))}
+        </div>
+      )}
+
+      {totalPages > 1 && (
+        <div className="flex justify-center gap-2 mt-4">
+          <button
+            onClick={() => handlePageChange(currentPage - 1)}
+            disabled={currentPage === 1}
+            className="px-3 py-1 bg-dashGreen-dark border border-dashBlack rounded-md text-dashYellow-light disabled:opacity-50"
+          >
+            Prev
+          </button>
+          <span className="px-2 py-1 text-sm text-dashYellow-light">
+            Page {currentPage} of {totalPages}
+          </span>
+          <button
+            onClick={() => handlePageChange(currentPage + 1)}
+            disabled={currentPage === totalPages}
+            className="px-3 py-1 bg-dashGreen-dark border border-dashBlack rounded-md text-dashYellow-light disabled:opacity-50"
+          >
+            Next
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add a new `TokenSearchList` component
- replace card list on homepage with searchable/paginated list

## Testing
- `npm test` *(fails: 0 tests)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683e1e6a7470832c80a813f9e39d4e26