### PR TITLE
Update theme to match Believe style

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -6,43 +6,43 @@
 
 @layer base {
   :root {
-    --background: 240 16% 9%; /* #13131A */
-    --foreground: 240 25% 92%; /* #E6E6F0 */
+    --background: 0 0% 100%; /* #ffffff */
+    --foreground: 0 0% 0%;   /* #000000 */
 
-    --card: 240 17% 13%; /* #1B1B26 */
-    --card-foreground: 240 25% 92%;
+    --card: 0 0% 100%; /* #ffffff */
+    --card-foreground: 0 0% 0%;
 
-    --popover: 240 17% 13%;
-    --popover-foreground: 240 25% 92%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 0 0% 0%;
 
-    --primary: 240 25% 92%;
-    --primary-foreground: 240 16% 9%;
+    --primary: 145 63% 49%; /* #2ecc71 */
+    --primary-foreground: 0 0% 100%;
 
-    --secondary: 240 17% 13%;
-    --secondary-foreground: 240 25% 92%;
+    --secondary: 0 0% 93%; /* #eeeeee */
+    --secondary-foreground: 0 0% 0%;
 
-    --muted: 240 17% 20%;
-    --muted-foreground: 240 9% 66%; /* #A0A0B0 */
+    --muted: 0 0% 96%; /* #f5f5f5 */
+    --muted-foreground: 0 0% 40%;
 
-    --accent: 33 93% 54%; /* Bitcoin Orange */
-    --accent-foreground: 240 16% 9%;
+    --accent: 145 63% 49%;
+    --accent-foreground: 0 0% 100%;
 
     --destructive: 359 79% 58%; /* Bright Red */
-    --destructive-foreground: 240 25% 92%;
+    --destructive-foreground: 0 0% 100%;
 
-    --border: 240 17% 20%;
-    --input: 240 17% 20%;
-    --ring: 240 25% 92%;
+    --border: 0 0% 90%;
+    --input: 0 0% 85%;
+    --ring: 145 63% 49%;
 
     --radius: 0.75rem;
 
-    --dashcoin-yellow: #E6E6F0;
-    --dashcoin-yellow-dark: #E6E6F0;
-    --dashcoin-yellow-light: #E6E6F0;
-    --dashcoin-green: #13131A;
-    --dashcoin-green-dark: #13131A;
-    --dashcoin-green-light: #1B1B26;
-    --dashcoin-green-accent: #1B1B26;
+    --dashcoin-yellow: #f5f5f5;
+    --dashcoin-yellow-dark: #eeeeee;
+    --dashcoin-yellow-light: #ffffff;
+    --dashcoin-green: #2ecc71;
+    --dashcoin-green-dark: #000000;
+    --dashcoin-green-light: #2ecc71;
+    --dashcoin-green-accent: #2ecc71;
     --dashcoin-black: #000000;
     --dashcoin-red: #E84042;
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -17,9 +17,9 @@ export default function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <html lang="en" suppressHydrationWarning className="dark">
-      <body className="font-sans bg-dashGreen-dark text-dashYellow-light min-h-screen">
-        <ThemeProvider attribute="class" defaultTheme="dark" enableSystem disableTransitionOnChange>
+    <html lang="en" suppressHydrationWarning>
+      <body className="font-sans bg-white text-black min-h-screen">
+        <ThemeProvider attribute="class" defaultTheme="light" enableSystem disableTransitionOnChange>
           {children}
         </ThemeProvider>
       </body>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -19,25 +19,25 @@ body {
 /* === ROOT VARIABLES & THEME === */
 @layer base {
   :root {
-    --background: 240 16% 9%;
-    --foreground: 240 25% 92%;
-    --card: 240 17% 13%;
-    --card-foreground: 240 25% 92%;
-    --popover: 240 17% 13%;
-    --popover-foreground: 240 25% 92%;
-    --primary: 240 25% 92%;
-    --primary-foreground: 240 16% 9%;
-    --secondary: 240 17% 13%;
-    --secondary-foreground: 240 25% 92%;
-    --muted: 240 17% 20%;
-    --muted-foreground: 240 9% 66%;
-    --accent: 33 93% 54%;
-    --accent-foreground: 240 16% 9%;
+    --background: 0 0% 100%;
+    --foreground: 0 0% 0%;
+    --card: 0 0% 100%;
+    --card-foreground: 0 0% 0%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 0 0% 0%;
+    --primary: 145 63% 49%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 0 0% 93%;
+    --secondary-foreground: 0 0% 0%;
+    --muted: 0 0% 96%;
+    --muted-foreground: 0 0% 40%;
+    --accent: 145 63% 49%;
+    --accent-foreground: 0 0% 100%;
     --destructive: 359 79% 58%;
-    --destructive-foreground: 240 25% 92%;
-    --border: 240 17% 20%;
-    --input: 240 17% 20%;
-    --ring: 240 25% 92%;
+    --destructive-foreground: 0 0% 100%;
+    --border: 0 0% 90%;
+    --input: 0 0% 85%;
+    --ring: 145 63% 49%;
     --radius: 0.5rem;
 
     /* Chart Colors */

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -20,23 +20,23 @@ const config = {
     extend: {
       colors: {
         dashGreen: {
-          DEFAULT: "#3a3a3a", // base grey
-          dark: "#1f2937", // deep slate
-          light: "#4f4f4f",
-          accent: "#656565",
-          card: "#2b2b2b",
-          cardDark: "#1e1e24",
+          DEFAULT: "#2ecc71",
+          dark: "#000000",
+          light: "#a6f4c5",
+          accent: "#2ecc71",
+          card: "#f5f5f5",
+          cardDark: "#eeeeee",
         },
         dashYellow: {
-          DEFAULT: "#f5f5f5", // off-white
-          light: "#fafafa",
-          dark: "#e5e5e5",
+          DEFAULT: "#f5f5f5",
+          light: "#ffffff",
+          dark: "#eeeeee",
         },
         dashRed: {
           DEFAULT: "#ff6666",
           dark: "#cc3333",
         },
-        dashBlack: "#27272A",
+        dashBlack: "#000000",
 
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",


### PR DESCRIPTION
## Summary
- switch site to light theme by default
- add Believe-style color variables
- update Tailwind colors for new palette

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683e2c85f1b8832c9cc5140015ab64ae