### PR TITLE
Remove Dune usage

### DIFF
--- a/app/api/tokens/route.ts
+++ b/app/api/tokens/route.ts
@@ -1,17 +1,5 @@
 import { NextResponse } from 'next/server';
-import { fetchAllTokensFromDune } from '@/app/actions/dune-actions';
 
 export async function GET() {
-  try {
-    const tokens = await fetchAllTokensFromDune();
-    return NextResponse.json(tokens);
-  } catch (error) {
-    console.error('Error fetching tokens:', error);
-    return new NextResponse(JSON.stringify({ error: 'Failed to fetch tokens' }), {
-      status: 500,
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    });
-  }
+  return NextResponse.json([]);
 }

--- a/app/creator-wallets/page.tsx
+++ b/app/creator-wallets/page.tsx
@@ -1,24 +1,8 @@
 import { Navbar } from "@/components/navbar";
-import { fetchAllTokensFromDune } from "../actions/dune-actions";
 import { fetchCreatorWalletLinks } from "../actions/googlesheet-action";
 
 export default async function CreatorWalletsPage() {
-  const tokens = await fetchAllTokensFromDune();
   const walletData = await fetchCreatorWalletLinks();
-
-  const walletMap = new Map(
-    walletData.map((d) => [d.symbol.toUpperCase(), { link: d.walletLink, activity: d.walletActivity }])
-  );
-
-  const tokensWithWallets = tokens.map((token) => {
-    const entry = walletMap.get(token.symbol.toUpperCase()) || { link: "", activity: "" };
-    return {
-      name: token.name || token.symbol,
-      symbol: token.symbol,
-      walletLink: entry.link,
-      walletActivity: entry.activity,
-    };
-  });
 
   return (
     <div className="min-h-screen">
@@ -30,15 +14,15 @@ export default async function CreatorWalletsPage() {
           <table className="w-full border-collapse">
             <thead>
               <tr className="bg-dashGreen-card dark:bg-dashGreen-cardDark border-b-2 border-dashBlack">
-                <th className="text-left py-3 px-4 text-dashYellow">Token Name</th>
+                <th className="text-left py-3 px-4 text-dashYellow">Token</th>
                 <th className="text-left py-3 px-4 text-dashYellow">Creator Wallet Link</th>
                 <th className="text-left py-3 px-4 text-dashYellow">Wallet Activity</th>
               </tr>
             </thead>
             <tbody>
-              {tokensWithWallets.map((token, idx) => (
+              {walletData.map((token, idx) => (
                 <tr key={idx} className="border-b border-dashGreen-light hover:bg-dashGreen-card dark:hover:bg-dashGreen-cardDark">
-                  <td className="py-3 px-4">{token.name}</td>
+                  <td className="py-3 px-4">{token.symbol}</td>
                   <td className="py-3 px-4">
                     {token.walletLink ? (
                       <a href={token.walletLink} target="_blank" rel="noopener noreferrer" className="text-dashYellow hover:text-dashYellow-dark underline">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,316 +1,102 @@
-import Image from "next/image";
+import { Navbar } from "@/components/navbar";
 import { DashcoinLogo } from "@/components/dashcoin-logo";
 import {
   DashcoinCard,
   DashcoinCardHeader,
   DashcoinCardTitle,
   DashcoinCardContent,
-  DashcoinCacheStatus,
 } from "@/components/ui/dashcoin-card";
-import { MarketCapChart } from "@/components/market-cap-chart";
-import { MarketCapPie } from "@/components/market-cap-pie";
-import {
-  fetchMarketCapOverTime,
-  fetchMarketStats,
-  fetchPaginatedTokens,
-  fetchTokenMarketCaps,
-  fetchTotalMarketCap,
-  getTimeUntilNextDuneRefresh,
-} from "./actions/dune-actions";
+import { DexscreenerChart } from "@/components/dexscreener-chart";
 import { fetchDexscreenerTokenData } from "./actions/dexscreener-actions";
 import { formatCurrency } from "@/lib/utils";
-import EnvSetup from "./env-setup";
-import { Suspense } from "react";
-import { Navbar } from "@/components/navbar";
 import { Twitter } from "lucide-react";
 
-const MarketCapChartWrapper = async ({
-  marketCapTimeDataPromise,
-}: {
-  marketCapTimeDataPromise: Promise<any>;
-}) => {
-  try {
-    const marketCapTimeData = await marketCapTimeDataPromise;
-    return <MarketCapChart data={marketCapTimeData || []} />;
-  } catch (error) {
-    console.error("Error in MarketCapChartWrapper:", error);
-    return (
-      <DashcoinCard className="h-48 flex items-center justify-center">
-        <p>Error loading chart data</p>
-      </DashcoinCard>
-    );
-  }
-};
-
-const MarketCapPieWrapper = async ({
-  tokenMarketCapsPromise,
-}: {
-  tokenMarketCapsPromise: Promise<any>;
-}) => {
-  try {
-    const tokenMarketCaps = await tokenMarketCapsPromise;
-    return <MarketCapPie data={tokenMarketCaps || []} />;
-  } catch (error) {
-    console.error("Error in MarketCapPieWrapper:", error);
-    return (
-      <DashcoinCard className="h-48 flex items-center justify-center">
-        <p>Error loading chart data</p>
-      </DashcoinCard>
-    );
-  }
-};
-
-
-const TokenCardListWrapper = async ({
-  tokenDataPromise,
-}: {
-  tokenDataPromise: Promise<any>;
-}) => {
-  try {
-    const tokenData = await tokenDataPromise;
-    const TokenCardList = (await import("@/components/token-card-list")).default;
-    return (
-      <TokenCardList
-        data={
-          tokenData || {
-            tokens: [],
-            page: 1,
-            pageSize: 10,
-            totalTokens: 0,
-            totalPages: 1,
-          }
-        }
-      />
-    );
-  } catch (error) {
-    console.error("Error in TokenCardListWrapper:", error);
-    return (
-      <DashcoinCard className="p-8 flex items-center justify-center">
-        <p className="text-center">Error loading token data</p>
-      </DashcoinCard>
-    );
-  }
-};
-
 export default async function Home() {
-  const hasDuneApiKey = !!process.env.DUNE_API_KEY;
-  if (!hasDuneApiKey) {
-    return <EnvSetup />;
-  }
   const dashcoinCA = "7gkgsqE2Uip7LUyrqEi8fyLPNSbn7GYu9yFgtxZwYUVa";
   const dashcoinTradeLink =
     "https://axiom.trade/meme/Fjq9SmWmtnETAVNbir1eXhrVANi1GDoHEA4nb4tNn7w6/@dashc";
   const dashcoinXLink = "https://x.com/dune_dashcoin";
-  const marketStatsPromise = fetchMarketStats().then(data => {
-    return data;
-  }).catch((error) => {
-    console.error("Error fetching market stats:", error);
-    return {
-      totalMarketCap: 0,
-      volume24h: 0,
-      transactions24h: 0,
-      feeEarnings24h: 0,
-      lifetimeVolume: 0,
-      coinLaunches: 0,
-    };
-  });
 
-  const tokenDataPromise = fetchPaginatedTokens(1, 10, "marketCap", "desc").then(data => {
-    return data;
-  }).catch((error) => {
-    console.error("error.fetching tokens makret cap", error);
-    return {}
-    });
-
-  const marketCapTimeDataPromise = fetchMarketCapOverTime().catch((error) => {
-    console.error("Error fetching market cap over time:", error);
-    return [];
-  });
-    
-  const tokenMarketCapsPromise = fetchTokenMarketCaps().then(data => {
-    return data;
-  }).catch((error) => {
-    console.error("error.fetching tokens makret cap", error);
-    return {}
-    });
-  
-  const totalMarketCapPromise = fetchTotalMarketCap().catch((error) => {
-    console.error("Error fetching total market cap:", error);
-    return { latest_data_at: new Date().toISOString(), total_marketcap_usd: 0 };
-  });
-
-  const dexscreenerDataPromise = fetchDexscreenerTokenData(dashcoinCA).catch(
-    (error) => {
-      console.error("Error fetching Dexscreener data:", error);
-      return null;
-    }
+  const dexscreenerData = await fetchDexscreenerTokenData(dashcoinCA).catch(
+    () => null,
   );
 
-  let marketStats, totalMarketCap, dexscreenerData;
-  try {
-    [marketStats, totalMarketCap, dexscreenerData] = await Promise.all([
-      marketStatsPromise,
-      totalMarketCapPromise,
-      dexscreenerDataPromise,
-    ]);
-  } catch (error) {
-    console.error("Error awaiting promises:", error);
-    marketStats = {
-      totalMarketCap: 0,
-      volume24h: 0,
-      transactions24h: 0,
-      feeEarnings24h: 0,
-      lifetimeVolume: 0,
-      coinLaunches: 0,
-    };
-    totalMarketCap = {
-      latest_data_at: new Date().toISOString(),
-      total_marketcap_usd: 0,
-    };
-    dexscreenerData = null;
-  }
+  let price = 0;
+  let marketCap = 0;
+  let volume24h = 0;
+  let change24h = 0;
+  let liquidity = 0;
+  let pairAddress = "";
 
-  let timeRemaining = 0;
-  let lastRefreshTime = new Date(Date.now() -  34 * 60 * 1000); // Default to 1 hours ago
-
-  try {
-    const refreshInfo = await getTimeUntilNextDuneRefresh();
-    timeRemaining = refreshInfo.timeRemaining;
-    lastRefreshTime = refreshInfo.lastRefreshTime;
-  } catch (error) {
-    console.error("Error getting refresh time info:", error);
-  }
-
-  const nextRefreshTime = new Date(
-    lastRefreshTime.getTime() + 1 * 60 * 60 * 1000
-  );
-
-  const formattedLastRefresh = lastRefreshTime.toLocaleString(undefined, {
-    dateStyle: "short",
-    timeStyle: "medium",
-  });
-  const formattedNextRefresh = nextRefreshTime.toLocaleString();
-
-  const hoursUntilRefresh = Math.floor(timeRemaining / (2 * 60 * 60 * 1000));
-  const minutesUntilRefresh = Math.floor(
-    (timeRemaining % (60 * 60 * 1000)) / (60 * 1000)
-  );
-
-  const formattedMarketCap = formatCurrency(
-    marketStats?.totalMarketCap || 0
-  );
-  const formattedVolume = formatCurrency(marketStats?.volume24h || 0);
-  const formattedFeeEarnings = formatCurrency(marketStats?.feeEarnings24h || 0);
-
-  let dashcPrice = 0;
-  let dashcMarketCap = 0;
-  let dashcVolume = 0;
-  let dashcChange24h = 0;
-  let dashcLiquidity = 0;
-
-  if (dexscreenerData && dexscreenerData.pairs && dexscreenerData.pairs.length > 0) {
+  if (dexscreenerData && dexscreenerData.pairs && dexscreenerData.pairs.length) {
     const pair = dexscreenerData.pairs[0];
-
-    dashcPrice = Number(pair.priceUsd || 0);
-    dashcMarketCap = pair.fdv || 0;
-    dashcVolume = pair.volume?.h24 || 0;
-    dashcChange24h = pair.priceChange?.h24 || 0;
-    dashcLiquidity = pair.liquidity?.usd || 0;
-    // pair address and timestamp are available but unused in this view
+    price = Number(pair.priceUsd || 0);
+    marketCap = pair.fdv || 0;
+    volume24h = pair.volume?.h24 || 0;
+    change24h = pair.priceChange?.h24 || 0;
+    liquidity = pair.liquidity?.usd || 0;
+    pairAddress = pair.pairAddress;
   }
 
   return (
     <div className="min-h-screen">
-      {/* Use the new Navbar component */}
-      <Navbar
-        dashcStats={{
-          tradeLink: dashcoinTradeLink,
-          marketCap: dashcMarketCap,
-        }}
-      />
-
-      <main className="container mx-auto px-4 py-4 space-y-4">
-
-
-        {/* Token Table */}
-        <div className="mt-2">
-          <h2 className="dashcoin-text text-3xl text-dashYellow mb-4">
-            Top Tokens by Market Cap
-          </h2>
-          <Suspense
-            fallback={
-              <DashcoinCard className="p-8 flex items-center justify-center">
-                <p className="text-center">
-                  Loading token data... This may take a moment as we fetch data for the
-                  top tokens.
-                </p>
-              </DashcoinCard>
-            }
-          >
-            <TokenCardListWrapper tokenDataPromise={tokenDataPromise} />
-          </Suspense>
-        </div>
-
-
-        {/* Market Stats */}
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+      <Navbar dashcStats={{ tradeLink: dashcoinTradeLink, marketCap }} />
+      <main className="container mx-auto px-4 py-6 space-y-8">
+        <h1 className="dashcoin-title text-4xl text-dashYellow mb-4">
+          Dashcoin Overview
+        </h1>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
           <DashcoinCard>
             <DashcoinCardHeader>
-              <DashcoinCardTitle>Total Market Cap of Believe Coins excluding Launchcoin</DashcoinCardTitle>
+              <DashcoinCardTitle>Price</DashcoinCardTitle>
             </DashcoinCardHeader>
             <DashcoinCardContent>
-              <p className="dashcoin-text text-3xl text-dashYellow">{formattedMarketCap}</p>
-              <div className="mt-2 pt-2 border-t border-dashGreen-light opacity-50">
-                <p className="text-sm">From Dune Analytics</p>
-              </div>
-              <DashcoinCacheStatus
-                lastUpdated={formattedLastRefresh}
-                nextUpdate={formattedNextRefresh}
-                hoursRemaining={hoursUntilRefresh}
-                minutesRemaining={minutesUntilRefresh}
-              />
-            </DashcoinCardContent>
-          </DashcoinCard>
-
-          <DashcoinCard>
-            <DashcoinCardHeader>
-              <DashcoinCardTitle>Total Creator Fees</DashcoinCardTitle>
-            </DashcoinCardHeader>
-            <DashcoinCardContent>
-              <p className="dashcoin-text text-3xl text-dashYellow">
-                {formattedFeeEarnings}
+              <p className="dashcoin-text text-2xl text-dashYellow">
+                ${price.toFixed(price < 0.01 ? 8 : 6)}
               </p>
-              <div className="mt-2 pt-2 border-t border-dashGreen-light opacity-50">
-                <p className="text-sm">Estimated at 0.3% of volume</p>
-              </div>
+              <p
+                className={`text-sm mt-2 ${change24h >= 0 ? "text-dashGreen-accent" : "text-dashRed"}`}
+              >
+                {change24h >= 0 ? "+" : ""}
+                {change24h.toFixed(2)}%
+              </p>
+            </DashcoinCardContent>
+          </DashcoinCard>
+          <DashcoinCard>
+            <DashcoinCardHeader>
+              <DashcoinCardTitle>Market Cap</DashcoinCardTitle>
+            </DashcoinCardHeader>
+            <DashcoinCardContent>
+              <p className="dashcoin-text text-2xl text-dashYellow">
+                ${formatCurrency(marketCap)}
+              </p>
+            </DashcoinCardContent>
+          </DashcoinCard>
+          <DashcoinCard>
+            <DashcoinCardHeader>
+              <DashcoinCardTitle>Volume (24h)</DashcoinCardTitle>
+            </DashcoinCardHeader>
+            <DashcoinCardContent>
+              <p className="dashcoin-text text-2xl text-dashYellow">
+                ${formatCurrency(volume24h)}
+              </p>
+            </DashcoinCardContent>
+          </DashcoinCard>
+          <DashcoinCard>
+            <DashcoinCardHeader>
+              <DashcoinCardTitle>Liquidity</DashcoinCardTitle>
+            </DashcoinCardHeader>
+            <DashcoinCardContent>
+              <p className="dashcoin-text text-2xl text-dashYellow">
+                ${formatCurrency(liquidity)}
+              </p>
             </DashcoinCardContent>
           </DashcoinCard>
         </div>
-
-        {/* Charts */}
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mt-0">
-          <Suspense
-            fallback={
-              <DashcoinCard className="h-48 flex items-center justify-center">
-                <p>Loading chart...</p>
-              </DashcoinCard>
-            }
-          >
-            <MarketCapChartWrapper marketCapTimeDataPromise={marketCapTimeDataPromise} />
-          </Suspense>
-          <Suspense
-            fallback={
-              <DashcoinCard className="h-48 flex items-center justify-center">
-                <p>Loading chart...</p>
-              </DashcoinCard>
-            }
-          >
-            <MarketCapPieWrapper tokenMarketCapsPromise={tokenMarketCapsPromise} />
-          </Suspense>
-        </div>
-
+        {pairAddress && (
+          <DexscreenerChart tokenAddress={pairAddress} title="Price Chart" />
+        )}
       </main>
-
       <footer className="container mx-auto py-8 px-4 mt-12 border-t border-dashGreen-light">
         <div className="flex flex-col md:flex-row justify-between items-center gap-4">
           <DashcoinLogo size={32} />

--- a/app/tokendetail/[symbol]/page.tsx
+++ b/app/tokendetail/[symbol]/page.tsx
@@ -1,10 +1,10 @@
 "use client";
-
 import { useState, useEffect } from "react";
-import { useRouter } from "next/navigation";
-import { Loader2, ArrowLeft, Twitter } from "lucide-react";
-import { DashcoinButton } from "@/components/ui/dashcoin-button";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { ArrowLeft, ExternalLink, Twitter } from "lucide-react";
 import { DashcoinLogo } from "@/components/dashcoin-logo";
+import { DashcoinButton } from "@/components/ui/dashcoin-button";
 import {
   DashcoinCard,
   DashcoinCardHeader,
@@ -13,42 +13,18 @@ import {
 } from "@/components/ui/dashcoin-card";
 import { DexscreenerChart } from "@/components/dexscreener-chart";
 import {
-  fetchTokenDetails,
-  getTimeUntilNextDuneRefresh,
-} from "@/app/actions/dune-actions";
-import {
   fetchDexscreenerTokenData,
   getTimeUntilNextDexscreenerRefresh,
 } from "@/app/actions/dexscreener-actions";
 import { formatCurrency } from "@/lib/utils";
-import { ExternalLink } from "lucide-react";
-import Link from "next/link";
-import { notFound } from "next/navigation";
 import { CopyAddress } from "@/components/copy-address";
 import { FoundersEdgeChecklist } from "@/components/founders-edge-checklist";
 
 interface TokenResearchData {
-  Symbol: string;
-  Score: number | string;
-  "Team Doxxed": number | string;
-  "Twitter Activity Level": number | string;
-  "Time Commitment": number | string;
-  "Prior Founder Experience": number | string;
-  "Product Maturity": number | string;
-  "Funding Status": number | string;
-  "Token-Product Integration Depth": number | string;
-  "Social Reach & Engagement Index": number | string;
-  "Relevant Links": string;
-  Comments: string;
-  "Wallet Link": string;
-  "Wallet Comments": string;
-  Twitter?: string;
   [key: string]: any;
 }
 
-async function fetchTokenResearch(
-  tokenSymbol: string,
-): Promise<TokenResearchData | null> {
+async function fetchTokenResearch(tokenSymbol: string): Promise<TokenResearchData | null> {
   const API_KEY = "AIzaSyC8QxJez_UTHUJS7vFj1J3Sje0CWS9tXyk";
   const SHEET_ID = "1Nra5QH-JFAsDaTYSyu-KocjbkZ0MATzJ4R-rUt-gLe0";
   const SHEET_NAME = "Dashcoin Scoring";
@@ -65,33 +41,22 @@ async function fetchTokenResearch(
     }
 
     const [header, ...rows] = data.values;
-
-    const canonicalMap: Record<string, string> = {
-      "Startup Experience": "Prior Founder Experience",
-      "Project Has Some Virality / Popularity":
-        "Social Reach & Engagement Index",
-    };
-
     const structured = rows.map((row: any) => {
       const entry: Record<string, any> = {};
       header.forEach((key: string, i: number) => {
-        const trimmed = key.trim();
-        const canonical = canonicalMap[trimmed] || trimmed;
-        entry[canonical] = row[i] || "";
+        entry[key.trim()] = row[i] || "";
       });
-      if (entry["Project"]) {
-        entry["Project"] = entry["Project"].toString().trim().toUpperCase();
-      }
       return entry;
     });
 
     const normalizedSymbol = tokenSymbol.toUpperCase();
-    const tokenData = structured.find(
-      (entry: any) =>
+    const tokenData = structured.find((entry: any) => {
+      return (
         entry["Project"] &&
         entry["Project"].toString().toUpperCase() === normalizedSymbol &&
-        entry["Score"],
-    );
+        entry["Score"]
+      );
+    });
 
     return tokenData || null;
   } catch (err) {
@@ -100,143 +65,63 @@ async function fetchTokenResearch(
   }
 }
 
-export default function TokenResearchPage({
-  params,
-}: {
-  params: { symbol: string };
-}) {
-  const { symbol } = params;
-  const [tokenData, setTokenData] = useState<any>(null);
+export default function TokenResearchPage({ params }: { params: { symbol: string } }) {
+  const tokenAddress = params.symbol;
   const [dexscreenerData, setDexscreenerData] = useState<any>(null);
+  const [researchData, setResearchData] = useState<TokenResearchData | null>(null);
   const [isLoading, setIsLoading] = useState(true);
-  const [duneLastRefresh, setDuneLastRefresh] = useState<Date | null>(null);
-  const [duneNextRefresh, setDuneNextRefresh] = useState<Date | null>(null);
-  const [duneTimeRemaining, setDuneTimeRemaining] = useState<number>(0);
   const [dexLastRefresh, setDexLastRefresh] = useState<Date | null>(null);
   const [dexNextRefresh, setDexNextRefresh] = useState<Date | null>(null);
-  const [dexTimeRemaining, setDexTimeRemaining] = useState<number>(0);
-  const router = useRouter();
-  const [researchData, setResearchData] = useState<TokenResearchData | null>(
-    null,
-  );
-  const [hasScore, setHasScore] = useState(false);
-
-  const formattedDuneLastRefresh = duneLastRefresh
-    ? duneLastRefresh.toLocaleString(undefined, {
-        dateStyle: "short",
-        timeStyle: "medium",
-      })
-    : "N/A";
-  const formattedDuneNextRefresh = duneNextRefresh
-    ? duneNextRefresh.toLocaleString(undefined, {
-        dateStyle: "short",
-        timeStyle: "medium",
-      })
-    : "N/A";
-  const formattedDexLastRefresh = dexLastRefresh
-    ? dexLastRefresh.toLocaleString(undefined, {
-        dateStyle: "short",
-        timeStyle: "medium",
-      })
-    : "N/A";
-  const formattedDexNextRefresh = dexNextRefresh
-    ? dexNextRefresh.toLocaleString(undefined, {
-        dateStyle: "short",
-        timeStyle: "medium",
-      })
-    : "N/A";
 
   useEffect(() => {
-    const getResearchData = async () => {
-      setIsLoading(true);
+    const load = async () => {
       try {
-        const data = await fetchTokenResearch(symbol);
-        setResearchData(data);
-        setHasScore(true);
-      } catch (error) {
-        console.error(`Error fetching research data for ${symbol}:`, error);
+        const dex = await fetchDexscreenerTokenData(tokenAddress);
+        if (!dex || !dex.pairs || dex.pairs.length === 0) {
+          notFound();
+        }
+        setDexscreenerData(dex.pairs[0]);
+        const research = await fetchTokenResearch(dex.pairs[0].baseToken.symbol);
+        setResearchData(research);
+        const dexCache = await getTimeUntilNextDexscreenerRefresh(`token:${tokenAddress}`);
+        if (dexCache.lastRefreshTime) {
+          setDexLastRefresh(dexCache.lastRefreshTime);
+          setDexNextRefresh(new Date(dexCache.lastRefreshTime.getTime() + 5 * 60 * 1000));
+        }
+      } catch (err) {
+        console.error("Error loading token research page:", err);
       } finally {
         setIsLoading(false);
       }
     };
+    load();
+  }, [tokenAddress]);
 
-    getResearchData();
-  }, [symbol]);
+  if (isLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p className="text-dashYellow-light">Loading...</p>
+      </div>
+    );
+  }
 
-  useEffect(() => {
-    async function loadData() {
-      try {
-        const duneTokenData = await fetchTokenDetails(symbol);
-        if (!duneTokenData) {
-          notFound();
-        }
+  if (!dexscreenerData) {
+    notFound();
+  }
 
-        setTokenData(duneTokenData);
-
-        const duneCache = await getTimeUntilNextDuneRefresh();
-        const dexCache = duneTokenData?.token
-          ? await getTimeUntilNextDexscreenerRefresh(
-              `token:${duneTokenData.token}`,
-            )
-          : { timeRemaining: 0, lastRefreshTime: null };
-
-        setDuneLastRefresh(duneCache.lastRefreshTime);
-        setDuneNextRefresh(
-          new Date(duneCache.lastRefreshTime.getTime() + 1 * 60 * 60 * 1000),
-        );
-        setDuneTimeRemaining(duneCache.timeRemaining);
-
-        if (dexCache.lastRefreshTime) {
-          setDexLastRefresh(dexCache.lastRefreshTime);
-          setDexNextRefresh(
-            new Date(dexCache.lastRefreshTime.getTime() + 5 * 60 * 1000),
-          );
-          setDexTimeRemaining(dexCache.timeRemaining);
-        }
-
-        if (duneTokenData && duneTokenData.token) {
-          const dexData = await fetchDexscreenerTokenData(duneTokenData.token);
-          if (dexData && dexData.pairs && dexData.pairs.length > 0) {
-            setDexscreenerData(dexData.pairs[0]);
-          }
-        }
-      } catch (error) {
-        console.error("Error loading token data:", error);
-      } finally {
-        setIsLoading(false);
-      }
-    }
-
-    loadData();
-  }, [symbol]);
-
-  const chartAddress =
-    dexscreenerData?.pairAddress || (tokenData && tokenData.token) || "";
-  const price = dexscreenerData?.priceUsd
-    ? Number.parseFloat(dexscreenerData.priceUsd)
-    : (tokenData && tokenData.price) || 0;
-  const change24h =
-    dexscreenerData?.priceChange?.h24 ||
-    (tokenData && tokenData.change24h) ||
-    0;
-  const volume24h =
-    dexscreenerData?.volume?.h24 || (tokenData && tokenData.volume24h) || 0;
-  const liquidity =
-    dexscreenerData?.liquidity?.usd || (tokenData && tokenData.liquidity) || 0;
-  const txs = dexscreenerData
-    ? (dexscreenerData.txns?.h24?.buys || 0) +
-      (dexscreenerData.txns?.h24?.sells || 0)
-    : (tokenData && tokenData.txs) || 0;
-  const buys = dexscreenerData?.txns?.h24?.buys || 0;
-  const sells = dexscreenerData?.txns?.h24?.sells || 0;
-  const change1h =
-    dexscreenerData?.priceChange?.h1 || (tokenData && tokenData.change1h) || 0;
-  const tokenSymbol = tokenData?.symbol || "Unknown";
-  const tokenAddress = tokenData?.token || "";
-  const createdTime = tokenData?.created_time
-    ? new Date(tokenData.created_time).toLocaleDateString()
-    : "Unknown";
-
+  const tokenSymbol = dexscreenerData.baseToken.symbol || "Unknown";
+  const tokenName = dexscreenerData.baseToken.name || tokenSymbol;
+  const price = Number.parseFloat(dexscreenerData.priceUsd || "0");
+  const volume24h = dexscreenerData.volume?.h24 || 0;
+  const liquidity = dexscreenerData.liquidity?.usd || 0;
+  const pairAddress = dexscreenerData.pairAddress || tokenAddress;
+  const change24h = dexscreenerData.priceChange?.h24 || 0;
+  const formattedDexLastRefresh = dexLastRefresh
+    ? dexLastRefresh.toLocaleString()
+    : "N/A";
+  const formattedDexNextRefresh = dexNextRefresh
+    ? dexNextRefresh.toLocaleString()
+    : "N/A";
 
   return (
     <div className="container mx-auto px-4 py-6">
@@ -248,10 +133,7 @@ export default function TokenResearchPage({
         </div>
       </header>
       <main className="container mx-auto px-4 py-6 space-y-8">
-        <Link
-          href="/"
-          className="flex items-center gap-2 text-dashYellow-light hover:text-dashYellow"
-        >
+        <Link href="/" className="flex items-center gap-2 text-dashYellow-light hover:text-dashYellow">
           <ArrowLeft className="h-4 w-4" />
           Back to Dashboard
         </Link>
@@ -259,10 +141,7 @@ export default function TokenResearchPage({
         <div className="flex flex-col md:flex-row justify-start gap-6 items-start md:items-center">
           <div className="flex justify-between text-center">
             <div className="flex flex-col">
-              <h1 className="dashcoin-title text-3xl text-dashYellow">
-                {tokenSymbol}
-              </h1>
-              <p className="text-xs opacity-60 mt-1">Created: {createdTime}</p>
+              <h1 className="dashcoin-title text-3xl text-dashYellow">{tokenSymbol}</h1>
             </div>
           </div>
           <DashcoinCard className="md:max-w-md mt-4 md:mt-0">
@@ -296,10 +175,7 @@ export default function TokenResearchPage({
           )}
           <div className="flex gap-2">
             <a
-              href={
-                dexscreenerData?.url ||
-                `https://axiom.trade/t/${tokenAddress}/dashc`
-              }
+              href={dexscreenerData.url || `https://axiom.trade/t/${tokenAddress}/dashc`}
               target="_blank"
               rel="noopener noreferrer"
               className="text-dashYellow hover:text-dashYellow-dark font-medium dashcoin-text flex items-center px-4 py-2 text-lg"
@@ -310,9 +186,7 @@ export default function TokenResearchPage({
           </div>
         </div>
 
-        {researchData && (
-          <FoundersEdgeChecklist data={researchData} showLegend />
-        )}
+        {researchData && <FoundersEdgeChecklist data={researchData} showLegend />}
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <DashcoinCard>
@@ -322,31 +196,12 @@ export default function TokenResearchPage({
             <DashcoinCardContent>
               <div className="grid grid-cols-2 gap-4">
                 <div>
-                  <p className="text-sm opacity-80">Buys</p>
-                  <p className="text-xl font-bold text-dashGreen-accent">
-                    {buys.toLocaleString()}
-                  </p>
-                </div>
-                <div>
-                  <p className="text-sm opacity-80">Sells</p>
-                  <p className="text-xl font-bold text-dashRed">
-                    {sells.toLocaleString()}
-                  </p>
+                  <p className="text-sm opacity-80">Volume</p>
+                  <p className="text-xl font-bold">{formatCurrency(volume24h)}</p>
                 </div>
                 <div>
                   <p className="text-sm opacity-80">Liquidity</p>
-                  <p className="text-xl font-bold">
-                    ${formatCurrency(liquidity)}
-                  </p>
-                </div>
-                <div>
-                  <p className="text-sm opacity-80">Price Change (1h)</p>
-                  <p
-                    className={`text-xl font-bold ${change1h >= 0 ? "text-dashGreen-accent" : "text-dashRed"}`}
-                  >
-                    {change1h >= 0 ? "+" : ""}
-                    {change1h.toFixed(2)}%
-                  </p>
+                  <p className="text-xl font-bold">{formatCurrency(liquidity)}</p>
                 </div>
               </div>
             </DashcoinCardContent>
@@ -360,31 +215,19 @@ export default function TokenResearchPage({
               <div className="space-y-3">
                 <div className="flex justify-between items-center">
                   <span className="text-sm opacity-80">Contract Address</span>
-                  {tokenAddress ? (
-                    <CopyAddress
-                      address={tokenAddress}
-                      showBackground={true}
-                      className="text-dashYellow-light hover:text-dashYellow"
-                    />
-                  ) : (
-                    <span className="text-sm">Not available</span>
-                  )}
+                  <CopyAddress
+                    address={tokenAddress}
+                    showBackground={true}
+                    className="text-dashYellow-light hover:text-dashYellow"
+                  />
                 </div>
-                <div className="flex justify-between">
-                  <span className="text-sm opacity-80">Symbol</span>
-                  <span className="text-sm">{tokenSymbol}</span>
-                </div>
-                <div className="flex justify-between">
-                  <span className="text-sm opacity-80">Created</span>
-                  <span className="text-sm">{createdTime}</span>
-                </div>
-                {dexscreenerData?.dexId && (
+                {dexscreenerData.dexId && (
                   <div className="flex justify-between">
                     <span className="text-sm opacity-80">DEX</span>
                     <span className="text-sm">{dexscreenerData.dexId}</span>
                   </div>
                 )}
-                {dexscreenerData?.pairAddress && (
+                {dexscreenerData.pairAddress && (
                   <div className="flex justify-between items-center">
                     <span className="text-sm opacity-80">Pair Address</span>
                     <CopyAddress
@@ -396,15 +239,8 @@ export default function TokenResearchPage({
                 )}
               </div>
               <div className="mt-4 pt-4 border-t border-dashGreen-light">
-                <p className="text-xs opacity-70 mb-1">
-                  Data Refresh Information:
-                </p>
-                <div className="grid grid-cols-2 gap-2 text-xs opacity-70">
-                  <div>
-                    <p>Dune data last updated:</p>
-                    <p className="font-mono">{formattedDuneLastRefresh}</p>
-                    <p>Next refresh: {formattedDuneNextRefresh}</p>
-                  </div>
+                <p className="text-xs opacity-70 mb-1">Data Refresh Information:</p>
+                <div className="grid grid-cols-1 gap-2 text-xs opacity-70">
                   <div>
                     <p>DEX data last updated:</p>
                     <p className="font-mono">{formattedDexLastRefresh}</p>
@@ -416,49 +252,17 @@ export default function TokenResearchPage({
           </DashcoinCard>
         </div>
 
-        {/* Dexscreener Chart */}
-        {chartAddress && (
-          <DexscreenerChart tokenAddress={chartAddress} title="Price Chart" />
+        {pairAddress && (
+          <DexscreenerChart tokenAddress={pairAddress} title="Price Chart" />
         )}
       </main>
-
-
-      {isLoading ? (
-        <div className="flex justify-center py-12">
-          <div className="flex flex-col items-center">
-            <Loader2 className="h-8 w-8 animate-spin text-dashYellow" />
-            <p className="mt-4 text-dashYellow-light">
-              Loading research data...
-            </p>
-          </div>
-        </div>
-      ) : !hasScore ? (
-        <DashcoinCard className="p-8 text-center">
-          <h2 className="text-xl font-semibold text-dashYellow">
-            No Research Available
-          </h2>
-          <p className="mt-4 text-dashYellow-light">
-            Research data is not yet available for {symbol}. Check back later or
-            try another token.
-          </p>
-        </DashcoinCard>
-      ) : (
-        <div className="space-y-8"></div>
-      )}
-
       <footer className="container mx-auto py-8 px-4 mt-12 border-t border-dashGreen-light">
         <div className="flex flex-col md:flex-row justify-between items-center gap-4">
           <DashcoinLogo size={32} />
-          <p className="text-sm opacity-80">
-            © 2025 Dashcoin. All rights reserved.
-          </p>
+          <p className="text-sm opacity-80">© 2025 Dashcoin. All rights reserved.</p>
           <div className="flex gap-4">
-            <DashcoinButton variant="outline" size="sm">
-              Docs
-            </DashcoinButton>
-            <DashcoinButton variant="outline" size="sm">
-              GitHub
-            </DashcoinButton>
+            <DashcoinButton variant="outline" size="sm">Docs</DashcoinButton>
+            <DashcoinButton variant="outline" size="sm">GitHub</DashcoinButton>
           </div>
         </div>
       </footer>

--- a/components/token-table.tsx
+++ b/components/token-table.tsx
@@ -27,7 +27,7 @@ import {
   TooltipContent,
   TooltipProvider,
 } from "@/components/ui/tooltip"
-import { fetchPaginatedTokens } from "@/app/actions/dune-actions"
+// Dune data removed; TokenData simplified
 import type { TokenData, PaginatedTokenResponse } from "@/types/dune"
 import { CopyAddress } from "@/components/copy-address"
 import { batchFetchTokensData } from "@/app/actions/dexscreener-actions"


### PR DESCRIPTION
## Summary
- remove Dune API usage from pages
- rely solely on Dexscreener data for token info
- simplify creator wallet page and API route

## Testing
- `npm test`
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683d32f46650832c9432fd1573919835