### PR TITLE
Update theme to Believe aesthetic

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -6,43 +6,43 @@
 
 @layer base {
   :root {
-    --background: 240 16% 9%; /* #13131A */
-    --foreground: 240 25% 92%; /* #E6E6F0 */
+    --background: 0 0% 100%; /* #ffffff */
+    --foreground: 0 0% 0%;   /* #000000 */
 
-    --card: 240 17% 13%; /* #1B1B26 */
-    --card-foreground: 240 25% 92%;
+    --card: 0 0% 100%; /* #ffffff */
+    --card-foreground: 0 0% 0%;
 
-    --popover: 240 17% 13%;
-    --popover-foreground: 240 25% 92%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 0 0% 0%;
 
-    --primary: 240 25% 92%;
-    --primary-foreground: 240 16% 9%;
+    --primary: 147 100% 39%; /* #00C851 */
+    --primary-foreground: 0 0% 100%;
 
-    --secondary: 240 17% 13%;
-    --secondary-foreground: 240 25% 92%;
+    --secondary: 0 0% 93%; /* #eeeeee */
+    --secondary-foreground: 0 0% 0%;
 
-    --muted: 240 17% 20%;
-    --muted-foreground: 240 9% 66%; /* #A0A0B0 */
+    --muted: 0 0% 96%; /* #f5f5f5 */
+    --muted-foreground: 0 0% 20%; /* #333333 */
 
-    --accent: 33 93% 54%; /* Bitcoin Orange */
-    --accent-foreground: 240 16% 9%;
+    --accent: 147 100% 39%;
+    --accent-foreground: 0 0% 100%;
 
     --destructive: 359 79% 58%; /* Bright Red */
-    --destructive-foreground: 240 25% 92%;
+    --destructive-foreground: 0 0% 100%;
 
-    --border: 240 17% 20%;
-    --input: 240 17% 20%;
-    --ring: 240 25% 92%;
+    --border: 0 0% 90%;
+    --input: 0 0% 85%;
+    --ring: 147 100% 39%;
 
     --radius: 0.75rem;
 
-    --dashcoin-yellow: #E6E6F0;
-    --dashcoin-yellow-dark: #E6E6F0;
-    --dashcoin-yellow-light: #E6E6F0;
-    --dashcoin-green: #13131A;
-    --dashcoin-green-dark: #13131A;
-    --dashcoin-green-light: #1B1B26;
-    --dashcoin-green-accent: #1B1B26;
+    --dashcoin-yellow: #000000; /* primary text */
+    --dashcoin-yellow-dark: #111111;
+    --dashcoin-yellow-light: #333333; /* secondary text */
+    --dashcoin-green: #00C851; /* primary accent */
+    --dashcoin-green-dark: #00A043;
+    --dashcoin-green-light: #5CF9A5;
+    --dashcoin-green-accent: #00C851;
     --dashcoin-black: #000000;
     --dashcoin-red: #E84042;
 
@@ -110,10 +110,10 @@
 
 /* Additional Dashcoin Card Styles */
 .dashcoin-card {
-  border: 1px solid var(--dashcoin-green-light);
+  border: 1px solid #e0e0e0;
   border-radius: 0.5rem;
-  background-color: var(--dashcoin-green);
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.2);
+  background-color: #ffffff;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
 }
 
 /* Tooltip custom styles */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -17,9 +17,9 @@ export default function RootLayout({
   children: React.ReactNode
 }>) {
   return (
-    <html lang="en" suppressHydrationWarning className="dark">
-      <body className="font-sans bg-dashGreen-dark text-dashYellow-light min-h-screen">
-        <ThemeProvider attribute="class" defaultTheme="dark" enableSystem disableTransitionOnChange>
+    <html lang="en" suppressHydrationWarning>
+      <body className="font-sans bg-white text-black min-h-screen">
+        <ThemeProvider attribute="class" defaultTheme="light" enableSystem disableTransitionOnChange>
           {children}
         </ThemeProvider>
       </body>

--- a/components/token-card.tsx
+++ b/components/token-card.tsx
@@ -43,11 +43,13 @@ export function TokenCard({ token, researchScore }: TokenCardProps) {
         <Link href={`/tokendetail/${tokenSymbol}`} className="hover:text-dashYellow">
           <div>
             <p className="text-2xl font-bold text-dashYellow">{tokenSymbol}</p>
-            {token.name && <p className="text-lg opacity-70">{token.name}</p>}
+            {token.name && (
+              <p className="text-lg text-dashYellow-light">{token.name}</p>
+            )}
           </div>
         </Link>
         {researchScore !== null && (
-          <span className="px-3 py-1 rounded-full bg-blue-600 text-base font-medium">
+          <span className="px-3 py-1 rounded-full bg-dashGreen text-white text-base font-medium">
             {researchScore.toFixed(1)}
           </span>
         )}
@@ -56,13 +58,15 @@ export function TokenCard({ token, researchScore }: TokenCardProps) {
       <div className="flex items-start justify-between text-base">
         <div className="flex items-center gap-3">
           <div>
-            <p className="opacity-70">Market Cap</p>
-            <p>{formatCurrency0(token.marketCap || 0)}</p>
+            <p className="text-dashYellow-light">Market Cap</p>
+            <p className="font-bold text-dashYellow">
+              {formatCurrency0(token.marketCap || 0)}
+            </p>
           </div>
           <span className="opacity-50">|</span>
-          <div className={`${change24h > 0 ? 'text-green-500' : change24h < 0 ? 'text-red-500' : ''}`}>
-            <p className="opacity-70">24h %</p>
-            <p>{change24h.toFixed(2)}%</p>
+          <div className={`${change24h > 0 ? 'text-green-600' : change24h < 0 ? 'text-red-500' : ''}`}> 
+            <p className="text-dashYellow-light">24h %</p>
+            <p className={`font-bold ${change24h === 0 ? 'text-dashYellow' : ''}`}>{change24h.toFixed(2)}%</p>
           </div>
         </div>
       </div>
@@ -94,7 +98,7 @@ export function TokenCard({ token, researchScore }: TokenCardProps) {
             href={tokenAddress ? `https://axiom.trade/t/${tokenAddress}/dashc` : '#'}
             target="_blank"
             rel="noopener noreferrer"
-            className="px-4 py-2 bg-blue-600 text-white rounded-md text-base hover:bg-blue-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-400 hover:shadow-md"
+            className="px-4 py-2 bg-dashGreen text-white rounded-md text-base hover:shadow focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-dashGreen-dark"
           >
             TRADE
           </a>

--- a/components/token-search-list.tsx
+++ b/components/token-search-list.tsx
@@ -77,7 +77,7 @@ export default function TokenSearchList() {
             setSearchTerm(e.target.value);
             setCurrentPage(1);
           }}
-          className="flex-grow px-3 py-2 bg-dashGreen-dark border border-dashBlack rounded-md text-dashYellow-light focus:outline-none"
+          className="flex-grow px-3 py-2 bg-white border border-gray-300 rounded-md text-dashYellow-light focus:outline-none"
         />
         <select
           value={pageSize}
@@ -85,7 +85,7 @@ export default function TokenSearchList() {
             setPageSize(Number(e.target.value));
             setCurrentPage(1);
           }}
-          className="px-3 py-2 bg-dashGreen-dark border border-dashBlack rounded-md text-dashYellow-light focus:outline-none"
+          className="px-3 py-2 bg-white border border-gray-300 rounded-md text-dashYellow-light focus:outline-none"
         >
           <option value={10}>10 per page</option>
           <option value={20}>20 per page</option>
@@ -108,7 +108,7 @@ export default function TokenSearchList() {
           <button
             onClick={() => handlePageChange(currentPage - 1)}
             disabled={currentPage === 1}
-            className="px-3 py-1 bg-dashGreen-dark border border-dashBlack rounded-md text-dashYellow-light disabled:opacity-50"
+            className="px-3 py-1 bg-dashGreen text-white rounded-md disabled:opacity-50 hover:shadow"
           >
             Prev
           </button>
@@ -118,7 +118,7 @@ export default function TokenSearchList() {
           <button
             onClick={() => handlePageChange(currentPage + 1)}
             disabled={currentPage === totalPages}
-            className="px-3 py-1 bg-dashGreen-dark border border-dashBlack rounded-md text-dashYellow-light disabled:opacity-50"
+            className="px-3 py-1 bg-dashGreen text-white rounded-md disabled:opacity-50 hover:shadow"
           >
             Next
           </button>

--- a/components/token-table.tsx
+++ b/components/token-table.tsx
@@ -557,7 +557,7 @@ export default function TokenTable({ data }: { data: PaginatedTokenResponse | To
                             href={tokenAddress ? `https://axiom.trade/t/${tokenAddress}/dashc` : "#"}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="px-3 py-1.5 bg-blue-600 text-white font-medium rounded-md hover:bg-blue-500 transition-colors text-sm min-w-[72px]"
+                            className="px-3 py-1.5 bg-dashGreen text-white font-medium rounded-md hover:shadow transition-colors text-sm min-w-[72px]"
                           >
                             TRADE
                           </a>

--- a/components/ui/dashcoin-button.tsx
+++ b/components/ui/dashcoin-button.tsx
@@ -15,10 +15,10 @@ const DashcoinButton = React.forwardRef<HTMLButtonElement, DashcoinButtonProps>(
         className={cn(
           "relative inline-flex items-center justify-center font-medium transition-colors focus-visible:outline-none disabled:pointer-events-none disabled:opacity-50 dashcoin-text",
           {
-            "bg-dashYellow text-dashBlack border-2 border-dashBlack hover:bg-dashYellow-dark": variant === "primary",
-            "bg-dashGreen-accent text-white border-2 border-dashBlack hover:bg-dashGreen-light":
-              variant === "secondary",
-            "bg-transparent border-2 border-dashYellow text-dashYellow hover:bg-dashGreen-dark": variant === "outline",
+          "bg-dashGreen text-white border-2 border-dashGreen-dark hover:brightness-110": variant === "primary",
+          "bg-white text-dashYellow border-2 border-gray-300 hover:bg-gray-100":
+            variant === "secondary",
+          "bg-transparent border-2 border-dashYellow text-dashYellow hover:bg-dashYellow-light": variant === "outline",
             "text-sm px-3 py-1 rounded-md shadow-[2px_2px_0_0_#222222]": size === "sm",
             "text-base px-4 py-2 rounded-lg shadow-[3px_3px_0_0_#222222]": size === "md",
             "text-lg px-6 py-3 rounded-xl shadow-[4px_4px_0_0_#222222]": size === "lg",

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -19,25 +19,25 @@ body {
 /* === ROOT VARIABLES & THEME === */
 @layer base {
   :root {
-    --background: 240 16% 9%;
-    --foreground: 240 25% 92%;
-    --card: 240 17% 13%;
-    --card-foreground: 240 25% 92%;
-    --popover: 240 17% 13%;
-    --popover-foreground: 240 25% 92%;
-    --primary: 240 25% 92%;
-    --primary-foreground: 240 16% 9%;
-    --secondary: 240 17% 13%;
-    --secondary-foreground: 240 25% 92%;
-    --muted: 240 17% 20%;
-    --muted-foreground: 240 9% 66%;
-    --accent: 33 93% 54%;
-    --accent-foreground: 240 16% 9%;
+    --background: 0 0% 100%;
+    --foreground: 0 0% 0%;
+    --card: 0 0% 100%;
+    --card-foreground: 0 0% 0%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 0 0% 0%;
+    --primary: 147 100% 39%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 0 0% 93%;
+    --secondary-foreground: 0 0% 0%;
+    --muted: 0 0% 96%;
+    --muted-foreground: 0 0% 20%;
+    --accent: 147 100% 39%;
+    --accent-foreground: 0 0% 100%;
     --destructive: 359 79% 58%;
-    --destructive-foreground: 240 25% 92%;
-    --border: 240 17% 20%;
-    --input: 240 17% 20%;
-    --ring: 240 25% 92%;
+    --destructive-foreground: 0 0% 100%;
+    --border: 0 0% 90%;
+    --input: 0 0% 85%;
+    --ring: 147 100% 39%;
     --radius: 0.5rem;
 
     /* Chart Colors */

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -20,23 +20,23 @@ const config = {
     extend: {
       colors: {
         dashGreen: {
-          DEFAULT: "#3a3a3a", // base grey
-          dark: "#1f2937", // deep slate
-          light: "#4f4f4f",
-          accent: "#656565",
-          card: "#2b2b2b",
-          cardDark: "#1e1e24",
+          DEFAULT: "#00C851",
+          dark: "#00A043",
+          light: "#5CF9A5",
+          accent: "#00C851",
+          card: "#f9f9f9",
+          cardDark: "#eeeeee",
         },
         dashYellow: {
-          DEFAULT: "#f5f5f5", // off-white
-          light: "#fafafa",
-          dark: "#e5e5e5",
+          DEFAULT: "#000000",
+          light: "#333333",
+          dark: "#111111",
         },
         dashRed: {
           DEFAULT: "#ff6666",
           dark: "#cc3333",
         },
-        dashBlack: "#27272A",
+        dashBlack: "#000000",
 
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",


### PR DESCRIPTION
## Summary
- refine global colors to use vibrant green and higher contrast text
- tweak card styles for softer shadows and white backgrounds
- update token card layout and trade button color
- restyle search bar and pagination buttons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683e2c85f1b8832c9cc5140015ab64ae