### PR TITLE
Improve market cap chart UX

### DIFF
--- a/components/market-cap-pie.tsx
+++ b/components/market-cap-pie.tsx
@@ -89,8 +89,13 @@ export function MarketCapPie({ data }: MarketCapPieProps) {
         responsive: true,
         maintainAspectRatio: false,
         plugins: {
+          title: {
+            display: true,
+            text: `Top ${topTokens.length} Tokens by Market Cap`,
+            color: dashYellowLight,
+          },
           legend: {
-            position: "right",
+            position: "bottom",
             labels: {
               color: dashYellowLight,
               font: {
@@ -120,8 +125,11 @@ export function MarketCapPie({ data }: MarketCapPieProps) {
         <DashcoinCardTitle>Market Cap Distribution</DashcoinCardTitle>
       </DashcoinCardHeader>
       <DashcoinCardContent>
-        <div className="h-64 bg-neutral-900 rounded-lg">
-          <canvas ref={chartRef} />
+        {(!data || data.length === 0) && (
+          <p className="text-center py-12">No market cap data available.</p>
+        )}
+        <div className="min-h-[300px] h-64 bg-white dark:bg-neutral-900 rounded-lg mt-4">
+          <canvas ref={chartRef} className="w-full h-full" />
         </div>
       </DashcoinCardContent>
     </DashcoinCard>


### PR DESCRIPTION
## Summary
- add title and move legend below chart
- show fallback message when no data is available
- use lighter background and minimum height for better readability

## Testing
- `npm test`
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683e44db6648832ca746b90c4ec6360f