### PR TITLE
Update $DASHC market cap bar style

### DIFF
--- a/components/dashc-stats-bar.tsx
+++ b/components/dashc-stats-bar.tsx
@@ -7,11 +7,11 @@ interface DashcStatsBarProps {
 
 export function DashcStatsBar({ tradeLink, marketCap }: DashcStatsBarProps) {
   return (
-    <div className="flex flex-wrap justify-between items-center gap-1 bg-dashGreen-dark rounded-lg border border-dashBlack py-1 px-2 w-full md:w-auto text-xs">
+    <div className="flex flex-wrap justify-between items-center gap-1 bg-dashYellow rounded-lg border border-gray-300 py-1 px-2 w-full md:w-auto text-xs shadow-sm">
       <div className="flex items-center gap-1">
-        <span className="font-medium text-dashYellow">$DASHC</span>
+        <span className="font-semibold text-green-700">$DASHC</span>
       </div>
-      <div className="flex flex-wrap gap-2 justify-center">
+      <div className="flex flex-wrap gap-2 justify-center text-dashBlack">
         <div className="text-center">
           <span className="opacity-70 font-medium">Market Cap</span>
           <p className="font-medium">{formatCurrency(marketCap)}</p>
@@ -22,7 +22,7 @@ export function DashcStatsBar({ tradeLink, marketCap }: DashcStatsBarProps) {
           href={tradeLink}
           target="_blank"
           rel="noopener noreferrer"
-          className="px-2 py-0.5 bg-dashYellow text-dashBlack font-medium rounded-md hover:bg-dashYellow-dark transition-colors flex items-center justify-center border border-dashBlack"
+          className="px-2 py-0.5 bg-transparent text-dashBlack font-medium rounded-md hover:bg-dashYellow-dark transition-colors flex items-center justify-center border border-gray-300"
         >
           TRADE
         </a>


### PR DESCRIPTION
## Summary
- lighten market cap bar background and borders
- adjust text colors to fit light theme
- keep trade button styling consistent with new bar

## Testing
- `npm test`
- `npx next lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683e444e041c832cbb7df2f7d64affd8