### PR TITLE
Remove Dune API dependency

### DIFF
--- a/app/api/tokens/route.ts
+++ b/app/api/tokens/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from 'next/server';
-import { fetchAllTokensFromDune } from '@/app/actions/dune-actions';
+import { fetchDefaultTokens } from '@/app/actions/dexscreener-actions';
 
 export async function GET() {
   try {
-    const tokens = await fetchAllTokensFromDune();
+    const tokens = await fetchDefaultTokens();
     return NextResponse.json(tokens);
   } catch (error) {
     console.error('Error fetching tokens:', error);

--- a/app/creator-wallets/page.tsx
+++ b/app/creator-wallets/page.tsx
@@ -1,9 +1,9 @@
 import { Navbar } from "@/components/navbar";
-import { fetchAllTokensFromDune } from "../actions/dune-actions";
+import { fetchDefaultTokens } from "../actions/dexscreener-actions";
 import { fetchCreatorWalletLinks } from "../actions/googlesheet-action";
 
 export default async function CreatorWalletsPage() {
-  const tokens = await fetchAllTokensFromDune();
+  const tokens = await fetchDefaultTokens();
   const walletData = await fetchCreatorWalletLinks();
 
   const walletMap = new Map(

--- a/app/tokendetail/[symbol]/page.tsx
+++ b/app/tokendetail/[symbol]/page.tsx
@@ -12,10 +12,7 @@ import {
   DashcoinCardContent,
 } from "@/components/ui/dashcoin-card";
 import { DexscreenerChart } from "@/components/dexscreener-chart";
-import {
-  fetchTokenDetails,
-  getTimeUntilNextDuneRefresh,
-} from "@/app/actions/dune-actions";
+import { fetchTokenDetails } from "@/app/actions/dexscreener-actions";
 import {
   fetchDexscreenerTokenData,
   getTimeUntilNextDexscreenerRefresh,
@@ -109,9 +106,6 @@ export default function TokenResearchPage({
   const [tokenData, setTokenData] = useState<any>(null);
   const [dexscreenerData, setDexscreenerData] = useState<any>(null);
   const [isLoading, setIsLoading] = useState(true);
-  const [duneLastRefresh, setDuneLastRefresh] = useState<Date | null>(null);
-  const [duneNextRefresh, setDuneNextRefresh] = useState<Date | null>(null);
-  const [duneTimeRemaining, setDuneTimeRemaining] = useState<number>(0);
   const [dexLastRefresh, setDexLastRefresh] = useState<Date | null>(null);
   const [dexNextRefresh, setDexNextRefresh] = useState<Date | null>(null);
   const [dexTimeRemaining, setDexTimeRemaining] = useState<number>(0);
@@ -121,18 +115,6 @@ export default function TokenResearchPage({
   );
   const [hasScore, setHasScore] = useState(false);
 
-  const formattedDuneLastRefresh = duneLastRefresh
-    ? duneLastRefresh.toLocaleString(undefined, {
-        dateStyle: "short",
-        timeStyle: "medium",
-      })
-    : "N/A";
-  const formattedDuneNextRefresh = duneNextRefresh
-    ? duneNextRefresh.toLocaleString(undefined, {
-        dateStyle: "short",
-        timeStyle: "medium",
-      })
-    : "N/A";
   const formattedDexLastRefresh = dexLastRefresh
     ? dexLastRefresh.toLocaleString(undefined, {
         dateStyle: "short",
@@ -166,25 +148,16 @@ export default function TokenResearchPage({
   useEffect(() => {
     async function loadData() {
       try {
-        const duneTokenData = await fetchTokenDetails(symbol);
-        if (!duneTokenData) {
+        const tokenInfo = await fetchTokenDetails(symbol);
+        if (!tokenInfo) {
           notFound();
         }
 
-        setTokenData(duneTokenData);
+        setTokenData(tokenInfo);
 
-        const duneCache = await getTimeUntilNextDuneRefresh();
-        const dexCache = duneTokenData?.token
-          ? await getTimeUntilNextDexscreenerRefresh(
-              `token:${duneTokenData.token}`,
-            )
+        const dexCache = tokenInfo?.token
+          ? await getTimeUntilNextDexscreenerRefresh(`token:${tokenInfo.token}`)
           : { timeRemaining: 0, lastRefreshTime: null };
-
-        setDuneLastRefresh(duneCache.lastRefreshTime);
-        setDuneNextRefresh(
-          new Date(duneCache.lastRefreshTime.getTime() + 1 * 60 * 60 * 1000),
-        );
-        setDuneTimeRemaining(duneCache.timeRemaining);
 
         if (dexCache.lastRefreshTime) {
           setDexLastRefresh(dexCache.lastRefreshTime);
@@ -194,8 +167,8 @@ export default function TokenResearchPage({
           setDexTimeRemaining(dexCache.timeRemaining);
         }
 
-        if (duneTokenData && duneTokenData.token) {
-          const dexData = await fetchDexscreenerTokenData(duneTokenData.token);
+        if (tokenInfo && tokenInfo.token) {
+          const dexData = await fetchDexscreenerTokenData(tokenInfo.token);
           if (dexData && dexData.pairs && dexData.pairs.length > 0) {
             setDexscreenerData(dexData.pairs[0]);
           }

--- a/components/token-table.tsx
+++ b/components/token-table.tsx
@@ -27,7 +27,7 @@ import {
   TooltipContent,
   TooltipProvider,
 } from "@/components/ui/tooltip"
-import { fetchPaginatedTokens } from "@/app/actions/dune-actions"
+import { fetchPaginatedTokens } from "@/app/actions/dexscreener-actions"
 import type { TokenData, PaginatedTokenResponse } from "@/types/dune"
 import { CopyAddress } from "@/components/copy-address"
 import { batchFetchTokensData } from "@/app/actions/dexscreener-actions"

--- a/data/defaultTokens.ts
+++ b/data/defaultTokens.ts
@@ -1,0 +1,8 @@
+export const DEFAULT_TOKENS = [
+  { symbol: 'DASHC', address: '7gkgsqE2Uip7LUyrqEi8fyLPNSbn7GYu9yFgtxZwYUVa' },
+  { symbol: 'GOON', address: 'GoonTokenAddressHere' },
+  { symbol: 'DUPE', address: 'DupeTokenAddressHere' },
+  { symbol: 'WIF', address: 'WifTokenAddressHere' },
+  { symbol: 'BOME', address: 'BomeTokenAddressHere' },
+  { symbol: 'BONK', address: 'BonkTokenAddressHere' },
+];


### PR DESCRIPTION
## Summary
- rely on Dexscreener for token data
- remove Dune API queries and cache status
- add sample token addresses

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683e42ff1200832cbb8c3cf3210ad7e2