### PR TITLE
Remove export card & fetch logos

### DIFF
--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -701,17 +701,6 @@ export default function ComparePage() {
               </DashcoinCardContent>
             </DashcoinCard>
 
-            <DashcoinCard className="min-w-[80vw] md:min-w-[500px] snap-center">
-              <DashcoinCardHeader>
-                <DashcoinCardTitle>Export This Comparison</DashcoinCardTitle>
-              </DashcoinCardHeader>
-              <DashcoinCardContent>
-                <div className="flex gap-4">
-                  <Button variant="outline" onClick={exportCsv}>CSV</Button>
-                  <Button variant="outline" onClick={exportPng}>PNG</Button>
-                </div>
-              </DashcoinCardContent>
-            </DashcoinCard>
 
             <DashcoinCard className="min-w-[80vw] md:min-w-[500px] snap-center">
               <DashcoinCardHeader>


### PR DESCRIPTION
## Summary
- remove the "Export This Comparison" section
- load token logos from Dexscreener in `TokenHeaderCard`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683e7a3d2004832c8e80925038b9ca0a