### PR TITLE
Fix token 24h change display

### DIFF
--- a/components/token-card-list.tsx
+++ b/components/token-card-list.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react"
 import { batchFetchTokensData } from "@/app/actions/dexscreener-actions"
+import { parseNumber } from "@/lib/utils"
 import { fetchTokenResearch } from "@/app/actions/googlesheet-action"
 import type { TokenData, PaginatedTokenResponse } from "@/types/dune"
 import { TokenCard } from "./token-card"
@@ -44,9 +45,9 @@ export default function TokenCardList({ data }: { data: PaginatedTokenResponse |
           const p = d.pairs[0]
           // Normalize numeric values from API
           result[addr] = {
-            volume24h: Number(p.volume?.h24) || 0,
-            change24h: Number(p.priceChange?.h24) || 0,
-            marketCap: Number(p.fdv) || 0,
+            volume24h: parseNumber(p.volume?.h24),
+            change24h: parseNumber(p.priceChange?.h24),
+            marketCap: parseNumber(p.fdv),
           }
         }
       })

--- a/components/token-card.tsx
+++ b/components/token-card.tsx
@@ -1,6 +1,6 @@
 import { DashcoinCard } from "@/components/ui/dashcoin-card"
 import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from "@/components/ui/tooltip"
-import { formatCurrency0 } from "@/lib/utils"
+import { formatCurrency0, parseNumber } from "@/lib/utils"
 import { canonicalChecklist } from "@/components/founders-edge-checklist"
 import { valueToScore } from "@/lib/score"
 import {
@@ -36,7 +36,7 @@ export function TokenCard({ token, researchScore }: TokenCardProps) {
   const tokenAddress = token.token || ""
   const tokenSymbol = token.symbol || "???"
   // Ensure change24h is treated as a number
-  const change24h = Number(token.change24h) || 0
+  const change24h = parseNumber(token.change24h)
 
   return (
     <DashcoinCard className="p-8 flex flex-col gap-6">

--- a/components/token-search-list.tsx
+++ b/components/token-search-list.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useMemo, useCallback } from "react";
 import type { TokenData } from "@/types/dune";
 import { fetchTokenResearch } from "@/app/actions/googlesheet-action";
 import { batchFetchTokensData } from "@/app/actions/dexscreener-actions";
+import { parseNumber } from "@/lib/utils";
 import { TokenCard } from "./token-card";
 import { DashcoinCard } from "@/components/ui/dashcoin-card";
 import { Loader2 } from "lucide-react";
@@ -34,9 +35,9 @@ export default function TokenSearchList() {
           const p = d.pairs[0];
           // Normalize numeric values from API
           result[addr] = {
-            volume24h: Number(p.volume?.h24) || 0,
-            change24h: Number(p.priceChange?.h24) || 0,
-            marketCap: Number(p.fdv) || 0,
+            volume24h: parseNumber(p.volume?.h24),
+            change24h: parseNumber(p.priceChange?.h24),
+            marketCap: parseNumber(p.fdv),
           };
         }
       });

--- a/components/token-table.tsx
+++ b/components/token-table.tsx
@@ -31,6 +31,7 @@ import { fetchPaginatedTokens } from "@/app/actions/dune-actions"
 import type { TokenData, PaginatedTokenResponse } from "@/types/dune"
 import { CopyAddress } from "@/components/copy-address"
 import { batchFetchTokensData } from "@/app/actions/dexscreener-actions"
+import { parseNumber } from "@/lib/utils"
 import { useCallback } from "react"
 import { fetchTokenResearch } from "@/app/actions/googlesheet-action"
 import { canonicalChecklist } from "@/components/founders-edge-checklist"
@@ -219,10 +220,10 @@ export default function TokenTable({ data }: { data: PaginatedTokenResponse | To
           const pair = data.pairs[0];
           // Normalize numeric values from API
           newDexData[address] = {
-            volume24h: Number(pair.volume?.h24) || 0,
-            change24h: Number(pair.priceChange?.h24) || 0,
-            changeM5: Number(pair.priceChange?.m5) || 0,
-            marketCap: Number(pair.fdv) || 0,
+            volume24h: parseNumber(pair.volume?.h24),
+            change24h: parseNumber(pair.priceChange?.h24),
+            changeM5: parseNumber(pair.priceChange?.m5),
+            marketCap: parseNumber(pair.fdv),
           };
         }
       });

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -108,3 +108,14 @@ export function hexToRgba(hex: string, alpha: number): string {
   const b = bigint & 255
   return `rgba(${r}, ${g}, ${b}, ${alpha})`
 }
+
+export function parseNumber(value: any): number {
+  if (value === null || value === undefined) return 0
+  if (typeof value === 'number') return value
+  if (typeof value === 'string') {
+    const sanitized = value.replace(/[^0-9.-]+/g, '')
+    const parsed = parseFloat(sanitized)
+    return isNaN(parsed) ? 0 : parsed
+  }
+  return 0
+}


### PR DESCRIPTION
## Summary
- normalize numeric values returned from Dexscreener so 24h change renders correctly
- ensure TokenCard converts `change24h` to number before display

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683e7eb833bc832caf95a4412bd4576f