### PR TITLE
Add Founder Interviews section

### DIFF
--- a/app/founder-interviews/page.tsx
+++ b/app/founder-interviews/page.tsx
@@ -1,0 +1,29 @@
+import { Navbar } from '@/components/navbar'
+import InterviewCard from '@/components/interview-card'
+import { interviews } from '@/data/interviews'
+
+export const metadata = {
+  title: 'Founder Interviews - Dashcoin',
+}
+
+export default function FounderInterviewsPage() {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar />
+      <section className="relative w-full h-64 flex items-center justify-center overflow-hidden bg-gradient-to-r from-dashGreen-dark via-dashGreen to-dashGreen-light">
+        <div className="absolute inset-0 opacity-20 animate-pulse bg-[url('/api/placeholder/800/200')] bg-repeat" />
+        <div className="relative z-10 text-center text-white px-4">
+          <h1 className="text-4xl font-bold mb-2">Founder Interviews</h1>
+          <p className="text-lg opacity-90">Conversations with the builders shaping the Internet Capital Markets</p>
+        </div>
+      </section>
+      <main className="container mx-auto px-4 py-8 flex-grow">
+        <div className="grid gap-6 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
+          {interviews.map((iv) => (
+            <InterviewCard key={iv.id} interview={iv} />
+          ))}
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/components/interview-card.tsx
+++ b/components/interview-card.tsx
@@ -1,0 +1,35 @@
+import Image from 'next/image'
+import Link from 'next/link'
+import { Button } from '@/components/ui/button'
+import { Interview } from '@/data/interviews'
+
+interface InterviewCardProps {
+  interview: Interview
+}
+
+export default function InterviewCard({ interview }: InterviewCardProps) {
+  const thumbnail = `https://img.youtube.com/vi/${interview.youtubeId}/hqdefault.jpg`
+  return (
+    <div className="group relative rounded-2xl overflow-hidden shadow-lg hover:shadow-xl transition-shadow duration-300">
+      <Image
+        src={thumbnail}
+        alt={`Thumbnail for ${interview.project}`}
+        width={400}
+        height={225}
+        className="w-full h-48 object-cover transform group-hover:scale-105 transition-transform duration-300"
+      />
+      <div className="absolute inset-0 bg-black/60 group-hover:bg-black/40 transition-colors duration-300" />
+      <div className="absolute bottom-0 left-0 right-0 p-4 flex flex-col gap-2 text-white">
+        <h3 className="text-xl font-semibold">{interview.project}</h3>
+        {interview.quote && (
+          <p className="text-sm opacity-90 group-hover:translate-y-0 translate-y-2 transition-transform duration-300">
+            {interview.quote}
+          </p>
+        )}
+        <Link href={`https://www.youtube.com/watch?v=${interview.youtubeId}`} target="_blank">
+          <Button className="mt-2">Watch Interview</Button>
+        </Link>
+      </div>
+    </div>
+  )
+}

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -36,6 +36,9 @@ export function Navbar({ dashcStats }: NavbarProps) {
             <NavLink href="/creator-wallets" active={pathname === "/creator-wallets"}>
               Creator Wallets
             </NavLink>
+            <NavLink href="/founder-interviews" active={pathname === "/founder-interviews"}>
+              Founder Interviews
+            </NavLink>
             <NavLink href="https://dashcoin-research.gitbook.io/dashcoin-research" active={false} external>
               Founder's Guide
             </NavLink>
@@ -53,6 +56,9 @@ export function Navbar({ dashcStats }: NavbarProps) {
           </NavLink>
           <NavLink href="/creator-wallets" active={pathname === "/creator-wallets"}>
             Creator Wallets
+          </NavLink>
+          <NavLink href="/founder-interviews" active={pathname === "/founder-interviews"}>
+            Founder Interviews
           </NavLink>
           <NavLink href="https://dashcoin-research.gitbook.io/dashcoin-research" active={false} external>
             Founder's Guide

--- a/data/interviews.ts
+++ b/data/interviews.ts
@@ -1,0 +1,27 @@
+export interface Interview {
+  id: string;
+  project: string;
+  youtubeId: string;
+  quote?: string;
+  tokenLogo?: string;
+}
+
+export const interviews: Interview[] = [
+  {
+    id: '1',
+    project: 'Dashcoin',
+    youtubeId: 'dQw4w9WgXcQ',
+    quote: 'Bringing transparency to Internet Capital Markets',
+  },
+  {
+    id: '2',
+    project: 'Believe',
+    youtubeId: '3GwjfUFyY6M',
+    quote: 'Building the future of tokenized communities',
+  },
+  {
+    id: '3',
+    project: 'Web3 Starter',
+    youtubeId: 'V-_O7nl0Ii0',
+  },
+];


### PR DESCRIPTION
## Summary
- add page for Founder Interviews
- create InterviewCard component
- add sample interview data
- link to the page from the navbar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683e7fb7e51c832c9e26639643d66624