### PR TITLE
Add hero banner styling on homepage

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -211,12 +211,12 @@ export default async function Home() {
           <div className="absolute inset-0 opacity-20 animate-pulse bg-[url('/api/placeholder/800/200')] bg-repeat" />
           <div className="relative z-10 text-center text-white px-6 py-4">
             <h1
-              className="font-bold mb-4 text-4xl sm:text-5xl md:text-6xl lg:text-[9rem]"
+              className="font-bold mb-4 text-2xl sm:text-3xl md:text-4xl lg:text-[4.5rem]"
             >
               Welcome to Dashcoin Research
             </h1>
             <p
-              className="opacity-90 text-lg sm:text-xl md:text-2xl lg:text-[4.5rem]"
+              className="opacity-90 text-sm sm:text-base md:text-lg lg:text-[2.25rem]"
             >
               Your command center for real-time data, token comparisons, and alpha across the Believe coin ecosystem. We surface the signal—so you can trade smarter.
             </p>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -207,13 +207,20 @@ export default async function Home() {
       <main className="container mx-auto px-4 py-4 space-y-4">
 
         {/* Welcome Blurb */}
-        <section className="animate-appear">
-          <DashcoinCard className="bg-white text-black dark:bg-[#111] dark:text-[#f5f5f5] text-center shadow-sm">
-            <h1 className="text-4xl font-bold mb-2">Welcome to Dashcoin Research</h1>
-            <p className="text-lg text-gray-600 dark:text-gray-300">
+        <section className="animate-appear relative w-full h-64 flex items-center justify-center overflow-hidden bg-dashGreen">
+          <div className="absolute inset-0 opacity-20 animate-pulse bg-[url('/api/placeholder/800/200')] bg-repeat" />
+          <div className="relative z-10 text-center text-white px-6 py-4">
+            <h1
+              className="font-bold mb-4 text-4xl sm:text-5xl md:text-6xl lg:text-[9rem]"
+            >
+              Welcome to Dashcoin Research
+            </h1>
+            <p
+              className="opacity-90 text-lg sm:text-xl md:text-2xl lg:text-[4.5rem]"
+            >
               Your command center for real-time data, token comparisons, and alpha across the Believe coin ecosystem. We surface the signal—so you can trade smarter.
             </p>
-          </DashcoinCard>
+          </div>
         </section>
 
 


### PR DESCRIPTION
## Summary
- update welcome banner to use same style as the Founder Interviews hero
- enlarge heading and blurb, add green background and placeholder pattern

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683e852ff3b8832cb6f4cd1f8ea87be4