### PR TITLE
Revise token card layout

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -116,6 +116,20 @@
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
 }
 
+/* Token card gradient styling */
+.token-card {
+  background-color: #f9f9f6;
+  background-image: linear-gradient(180deg, #f9f9f6, #eefbf3);
+  border-radius: 0.5rem;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  transition: transform 0.2s ease, background-image 0.2s ease, box-shadow 0.2s ease;
+}
+.token-card:hover {
+  transform: translateY(-2px);
+  background-image: linear-gradient(180deg, #f9f9f6, #e5f6ea);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+}
+
 /* Tooltip custom styles */
 .recharts-tooltip-wrapper .recharts-default-tooltip {
   background-color: var(--dashcoin-green-dark) !important;

--- a/components/token-card.tsx
+++ b/components/token-card.tsx
@@ -38,7 +38,7 @@ export function TokenCard({ token, researchScore }: TokenCardProps) {
   const change24h = token.change24h || 0
 
   return (
-    <DashcoinCard className="p-8 flex flex-col gap-6">
+    <DashcoinCard className="token-card p-8 flex flex-col gap-6 transition-all duration-200 hover:-translate-y-0.5">
       <div className="flex justify-between items-start">
         <Link href={`/tokendetail/${tokenSymbol}`} className="hover:text-dashYellow">
           <div>

--- a/components/token-search-list.tsx
+++ b/components/token-search-list.tsx
@@ -161,7 +161,7 @@ export default function TokenSearchList() {
       {paginatedTokens.length === 0 ? (
         <DashcoinCard className="p-8 text-center">No tokens found.</DashcoinCard>
       ) : (
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 mx-auto px-4 sm:px-8 lg:px-[20%]">
           {paginatedTokens.map((token, idx) => (
             <TokenCard
               key={idx}


### PR DESCRIPTION
## Summary
- center token grid with side padding
- add ambient gradient styling for token cards
- animate token cards on hover

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683e8a30bc78832c85763f4686bb30c7