### PR TITLE
Add sorting and filtering controls

### DIFF
--- a/components/token-card-list.tsx
+++ b/components/token-card-list.tsx
@@ -78,7 +78,7 @@ export default function TokenCardList({ data }: { data: PaginatedTokenResponse |
 
   return (
     <div
-      className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6"
+      className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6 auto-rows-fr"
     >
       {tokensWithData.map((token, idx) => {
         const researchScore = token.score ?? null

--- a/components/token-card.tsx
+++ b/components/token-card.tsx
@@ -38,7 +38,7 @@ export function TokenCard({ token, researchScore }: TokenCardProps) {
   const change24h = token.change24h || 0
 
   return (
-    <DashcoinCard className="p-8 flex flex-col gap-6">
+    <DashcoinCard className="p-6 sm:p-8 flex flex-col gap-4 sm:gap-6 h-full bg-gradient-to-br from-white via-white to-green-50 rounded-xl shadow">
       <div className="flex justify-between items-start">
         <Link href={`/tokendetail/${tokenSymbol}`} className="hover:text-dashYellow">
           <div>


### PR DESCRIPTION
## Summary
- improve token card look and feel
- make grid rows equal height
- add sorting and market cap filter to the token search list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f22dc4fb4832c886295721ebbb86e