### PR TITLE
Implement sorting and market cap filter

### DIFF
--- a/components/token-search-list.tsx
+++ b/components/token-search-list.tsx
@@ -22,6 +22,9 @@ export default function TokenSearchList() {
   const [searchTerm, setSearchTerm] = useState("");
   const [pageSize, setPageSize] = useState(10);
   const [currentPage, setCurrentPage] = useState(1);
+  const [sortOption, setSortOption] = useState("default");
+  const [showFilter, setShowFilter] = useState(false);
+  const [marketCapFilter, setMarketCapFilter] = useState("all");
   const fetchDexData = useCallback(async (tokenList: TokenData[]) => {
     const addresses = tokenList.map(t => t.token).filter(Boolean);
     if (!addresses.length) return;
@@ -89,24 +92,54 @@ export default function TokenSearchList() {
     });
   }, [tokens, researchScores, dexscreenerData]);
 
-  const filteredTokens = useMemo(() => {
-    if (!searchTerm.trim()) return tokensWithData;
-    const term = searchTerm.toLowerCase();
-    return tokensWithData.filter(t => {
-      return (
-        (t.symbol && t.symbol.toLowerCase().includes(term)) ||
-        (t.name && t.name.toLowerCase().includes(term)) ||
-        (t.description && t.description.toLowerCase().includes(term))
-      );
-    });
-  }, [tokensWithData, searchTerm]);
+  const filteredAndSortedTokens = useMemo(() => {
+    let result = tokensWithData;
 
-  const totalPages = Math.max(1, Math.ceil(filteredTokens.length / pageSize));
+    // text search
+    if (searchTerm.trim()) {
+      const term = searchTerm.toLowerCase();
+      result = result.filter(t => {
+        return (
+          (t.symbol && t.symbol.toLowerCase().includes(term)) ||
+          (t.name && t.name.toLowerCase().includes(term)) ||
+          (t.description && t.description.toLowerCase().includes(term))
+        );
+      });
+    }
+
+    // market cap filter
+    result = result.filter(t => {
+      const cap = t.marketCap || 0;
+      switch (marketCapFilter) {
+        case "above5m":
+          return cap >= 5_000_000;
+        case "1to5m":
+          return cap >= 1_000_000 && cap < 5_000_000;
+        case "500kto1m":
+          return cap >= 500_000 && cap < 1_000_000;
+        case "100kto500k":
+          return cap >= 100_000 && cap < 500_000;
+        default:
+          return true;
+      }
+    });
+
+    // sorting
+    if (sortOption === "mc-desc") {
+      result = [...result].sort((a, b) => (b.marketCap || 0) - (a.marketCap || 0));
+    } else if (sortOption === "mc-asc") {
+      result = [...result].sort((a, b) => (a.marketCap || 0) - (b.marketCap || 0));
+    }
+
+    return result;
+  }, [tokensWithData, searchTerm, sortOption, marketCapFilter]);
+
+  const totalPages = Math.max(1, Math.ceil(filteredAndSortedTokens.length / pageSize));
 
   const paginatedTokens = useMemo(() => {
     const start = (currentPage - 1) * pageSize;
-    return filteredTokens.slice(start, start + pageSize);
-  }, [filteredTokens, currentPage, pageSize]);
+    return filteredAndSortedTokens.slice(start, start + pageSize);
+  }, [filteredAndSortedTokens, currentPage, pageSize]);
 
   useEffect(() => {
     fetchDexData(paginatedTokens);
@@ -144,18 +177,105 @@ export default function TokenSearchList() {
           }}
           className="flex-grow px-3 py-2 bg-white border border-gray-300 rounded-md text-dashYellow-light focus:outline-none"
         />
-        <select
-          value={pageSize}
-          onChange={e => {
-            setPageSize(Number(e.target.value));
-            setCurrentPage(1);
-          }}
-          className="px-3 py-2 bg-white border border-gray-300 rounded-md text-dashYellow-light focus:outline-none"
-        >
-          <option value={10}>10 per page</option>
-          <option value={20}>20 per page</option>
-          <option value={50}>50 per page</option>
-        </select>
+        <div className="flex gap-2">
+          <select
+            value={sortOption}
+            onChange={e => {
+              setSortOption(e.target.value);
+              setCurrentPage(1);
+            }}
+            className="px-3 py-2 bg-white border border-gray-300 rounded-md text-dashYellow-light focus:outline-none"
+          >
+            <option value="default">Default order</option>
+            <option value="mc-desc">Market Cap: High to Low</option>
+            <option value="mc-asc">Market Cap: Low to High</option>
+          </select>
+          <div className="relative">
+            <button
+              type="button"
+              onClick={() => setShowFilter(p => !p)}
+              className="px-3 py-2 bg-white border border-gray-300 rounded-md text-dashYellow-light focus:outline-none"
+            >
+              Filter
+            </button>
+            {showFilter && (
+              <div className="absolute right-0 mt-1 bg-white border border-gray-300 rounded-md p-2 space-y-1 z-10 text-sm">
+                <label className="flex items-center gap-2">
+                  <input
+                    type="radio"
+                    value="all"
+                    checked={marketCapFilter === 'all'}
+                    onChange={e => {
+                      setMarketCapFilter(e.target.value);
+                      setCurrentPage(1);
+                    }}
+                  />
+                  All
+                </label>
+                <label className="flex items-center gap-2">
+                  <input
+                    type="radio"
+                    value="above5m"
+                    checked={marketCapFilter === 'above5m'}
+                    onChange={e => {
+                      setMarketCapFilter(e.target.value);
+                      setCurrentPage(1);
+                    }}
+                  />
+                  Above $5M
+                </label>
+                <label className="flex items-center gap-2">
+                  <input
+                    type="radio"
+                    value="1to5m"
+                    checked={marketCapFilter === '1to5m'}
+                    onChange={e => {
+                      setMarketCapFilter(e.target.value);
+                      setCurrentPage(1);
+                    }}
+                  />
+                  $1M – $5M
+                </label>
+                <label className="flex items-center gap-2">
+                  <input
+                    type="radio"
+                    value="500kto1m"
+                    checked={marketCapFilter === '500kto1m'}
+                    onChange={e => {
+                      setMarketCapFilter(e.target.value);
+                      setCurrentPage(1);
+                    }}
+                  />
+                  $500K – $1M
+                </label>
+                <label className="flex items-center gap-2">
+                  <input
+                    type="radio"
+                    value="100kto500k"
+                    checked={marketCapFilter === '100kto500k'}
+                    onChange={e => {
+                      setMarketCapFilter(e.target.value);
+                      setCurrentPage(1);
+                    }}
+                  />
+                  $100K – $500K
+                </label>
+              </div>
+            )}
+          </div>
+          <select
+            value={pageSize}
+            onChange={e => {
+              setPageSize(Number(e.target.value));
+              setCurrentPage(1);
+            }}
+            className="px-3 py-2 bg-white border border-gray-300 rounded-md text-dashYellow-light focus:outline-none"
+          >
+            <option value={10}>10 per page</option>
+            <option value={20}>20 per page</option>
+            <option value={50}>50 per page</option>
+          </select>
+        </div>
       </div>
 
       {paginatedTokens.length === 0 ? (


### PR DESCRIPTION
## Summary
- add sort and market cap filter controls to `TokenSearchList`
- handle sorting and filtering logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683f257a8454832c90252f5b16d546a4