### PR TITLE
Adjust token list defaults to 12

### DIFF
--- a/components/token-search-list.tsx
+++ b/components/token-search-list.tsx
@@ -20,7 +20,7 @@ export default function TokenSearchList() {
   const [researchScores, setResearchScores] = useState<ResearchScoreData[]>([]);
   const [dexscreenerData, setDexscreenerData] = useState<Record<string, any>>({});
   const [searchTerm, setSearchTerm] = useState("");
-  const [pageSize, setPageSize] = useState(10);
+  const [pageSize, setPageSize] = useState(12);
   const [currentPage, setCurrentPage] = useState(1);
   const fetchDexData = useCallback(async (tokenList: TokenData[]) => {
     const addresses = tokenList.map(t => t.token).filter(Boolean);
@@ -152,9 +152,9 @@ export default function TokenSearchList() {
           }}
           className="px-3 py-2 bg-white border border-gray-300 rounded-md text-dashYellow-light focus:outline-none"
         >
-          <option value={10}>10 per page</option>
-          <option value={20}>20 per page</option>
-          <option value={50}>50 per page</option>
+          <option value={12}>12 per page</option>
+          <option value={24}>24 per page</option>
+          <option value={56}>56 per page</option>
         </select>
       </div>
 

--- a/components/token-table.tsx
+++ b/components/token-table.tsx
@@ -56,14 +56,14 @@ interface ResearchScoreData {
 
 export default function TokenTable({ data }: { data: PaginatedTokenResponse | TokenData[] }) {
   const initialData = Array.isArray(data)
-    ? { tokens: data, page: 1, pageSize: 10, totalTokens: data.length, totalPages: Math.ceil(data.length / 10) }
+    ? { tokens: data, page: 1, pageSize: 12, totalTokens: data.length, totalPages: Math.ceil(data.length / 12) }
     : data
 
   const [searchTerm, setSearchTerm] = useState("")
   const [sortField, setSortField] = useState("marketCap")
   const [sortDirection, setSortDirection] = useState("desc")
   const [currentPage, setCurrentPage] = useState(initialData.page || 1)
-  const [itemsPerPage, setItemsPerPage] = useState(initialData.pageSize || 10)
+  const [itemsPerPage, setItemsPerPage] = useState(initialData.pageSize || 12)
   const [isLoading, setIsLoading] = useState(false)
   const [tokenData, setTokenData] = useState<PaginatedTokenResponse>(initialData)
   const [filteredTokens, setFilteredTokens] = useState<TokenData[]>(initialData.tokens || [])
@@ -418,9 +418,9 @@ export default function TokenTable({ data }: { data: PaginatedTokenResponse | To
             }}
             className="px-3 py-2 bg-dashGreen-dark border border-dashBlack rounded-md text-dashYellow-light focus:outline-none focus:ring-2 focus:ring-dashYellow"
           >
-            <option value="10">10 per page</option>
-            <option value="20">20 per page</option>
-            <option value="50">50 per page</option>
+            <option value="12">12 per page</option>
+            <option value="24">24 per page</option>
+            <option value="56">56 per page</option>
           </select>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- show 12 tokens per page by default
- update per-page dropdown options to 12, 24 and 56

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f2f943b00832c9c85e6d9d6b3653e