### PR TITLE
Add Founder's Edge checklist page

### DIFF
--- a/__tests__/googlesheet-action.test.js
+++ b/__tests__/googlesheet-action.test.js
@@ -1,0 +1,46 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { fetchTokenResearch } from '../app/actions/googlesheet-action'
+
+const sample = {
+  values: [
+    [
+      'Project',
+      'Score',
+      'Team Doxxed',
+      'Twitter Activity Level',
+      'Time Commitment',
+      'Prior Founder Experience',
+      'Product Maturity',
+      'Funding Status',
+      'Token-Product Integration Depth',
+      'Social Reach & Engagement Index',
+      'Data Integration',
+    ],
+    [
+      'ABC',
+      '80',
+      'Yes',
+      'No',
+      'Unknown',
+      'Yes',
+      'No',
+      'Yes',
+      'Unknown',
+      'No',
+      'Yes',
+    ],
+  ],
+}
+
+test('fetchTokenResearch parses sheet data', async () => {
+  const originalFetch = global.fetch
+  global.fetch = async () => ({ json: async () => sample })
+  const res = await fetchTokenResearch()
+  global.fetch = originalFetch
+  assert.equal(res.length, 1)
+  const token = res[0]
+  assert.equal(token.symbol, 'ABC')
+  assert.equal(token['Team Doxxed'], 'Yes')
+  assert.equal(token['Data Integration'], 'Yes')
+})

--- a/app/actions/googlesheet-action.ts
+++ b/app/actions/googlesheet-action.ts
@@ -55,6 +55,7 @@ export async function fetchTokenResearch(): Promise<ResearchScoreData[]> {
         'Funding Status',
         'Token-Product Integration Depth',
         'Social Reach & Engagement Index',
+        'Data Integration',
       ].forEach(label => {
         result[label] = entry[label] ?? '';
       });

--- a/app/founders-edge/page.tsx
+++ b/app/founders-edge/page.tsx
@@ -1,0 +1,25 @@
+import { Navbar } from '@/components/navbar'
+import { FoundersEdgeChecklist } from '@/components/founders-edge-checklist'
+import { fetchTokenResearch } from '@/app/actions/googlesheet-action'
+
+export const metadata = {
+  title: "Founder's Edge Checklist - Dashcoin",
+}
+
+export default async function FoundersEdgePage() {
+  const data = await fetchTokenResearch()
+  const token = data[0] || null
+
+  return (
+    <div className="min-h-screen flex flex-col">
+      <Navbar />
+      <main className="container mx-auto px-4 py-8 flex justify-center">
+        {token ? (
+          <FoundersEdgeChecklist data={token} showLegend />
+        ) : (
+          <p>No data found.</p>
+        )}
+      </main>
+    </div>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -210,10 +210,15 @@ export default async function Home() {
         <section className="animate-appear">
           <DashcoinCard className="bg-white text-black dark:bg-[#111] dark:text-[#f5f5f5] text-center shadow-sm">
             <h1 className="text-4xl font-bold mb-2">Welcome to Dashcoin Research</h1>
-            <p className="text-lg text-gray-600 dark:text-gray-300">
-              Your command center for real-time data, token comparisons, and alpha across the Believe coin ecosystem. We surface the signal—so you can trade smarter.
-            </p>
-          </DashcoinCard>
+          <p className="text-lg text-gray-600 dark:text-gray-300">
+            Your command center for real-time data, token comparisons, and alpha across the Believe coin ecosystem. We surface the signal—so you can trade smarter.
+          </p>
+          <p className="mt-4">
+            <a href="/founders-edge" className="text-dashGreen hover:underline">
+              View the Founder's Edge Checklist
+            </a>
+          </p>
+        </DashcoinCard>
         </section>
 
 

--- a/components/founders-edge-checklist.tsx
+++ b/components/founders-edge-checklist.tsx
@@ -1,5 +1,5 @@
 import { DashcoinCard } from "@/components/ui/dashcoin-card";
-import { CheckCircle, XCircle, MinusCircle } from "lucide-react";
+import { CheckCircle, XCircle, Circle } from "lucide-react";
 import React from "react";
 import { gradeMaps, valueToScore } from "@/lib/score";
 
@@ -12,17 +12,30 @@ export const canonicalChecklist = [
   "Funding Status",
   "Token-Product Integration Depth",
   "Social Reach & Engagement Index",
+  "Data Integration",
 ];
 
-function getIcon(value: number) {
-  switch (value) {
-    case 2:
-      return <CheckCircle className="text-green-500 w-5 h-5" />;
-    case 1:
-      return <XCircle className="text-red-500 w-5 h-5" />;
-    default:
-      return <MinusCircle className="text-yellow-400 w-5 h-5" />;
+export const traitColorMap: Record<string, string> = {
+  Yes: "green",
+  No: "red",
+  Unknown: "yellow",
+};
+
+function getIcon(status: "Yes" | "No" | "Unknown") {
+  if (status === "Yes") {
+    return <CheckCircle className="text-green-400 w-4 h-4" />;
   }
+  if (status === "No") {
+    return <XCircle className="text-red-400 w-4 h-4" />;
+  }
+  return <Circle className="text-yellow-400 w-4 h-4 fill-yellow-400" />;
+}
+
+function getStatus(value: any, label: string): "Yes" | "No" | "Unknown" {
+  const score = valueToScore(value, (gradeMaps as any)[label]);
+  if (score === 2) return "Yes";
+  if (score === 1) return "No";
+  return "Unknown";
 }
 
 interface ChecklistProps {
@@ -33,15 +46,22 @@ interface ChecklistProps {
 export function FoundersEdgeChecklist({ data, showLegend = false }: ChecklistProps) {
   if (!data) return null;
   const score = Number(data["Score"]) || 0;
-  const borderColor =
-    score >= 70 ? "border-green-500" : score >= 40 ? "border-yellow-500" : "border-red-500";
+  const statuses = canonicalChecklist.map(label => getStatus(data[label], label));
+  const positiveCount = statuses.filter(s => s === "Yes").length;
+  const highConfidence = positiveCount > canonicalChecklist.length / 2;
+  const borderColor = score >= 70 ? "border-green-500" : score >= 40 ? "border-yellow-500" : "border-red-500";
 
   return (
     <DashcoinCard
-      className={`relative bg-zinc-900 p-10 rounded-2xl shadow-lg ${borderColor}`}
+      className={`relative bg-white dark:bg-zinc-900 text-black dark:text-white p-6 rounded-2xl shadow ${borderColor}`}
     >
+      {highConfidence && (
+        <div className="absolute top-3 right-3 bg-green-600 text-white text-xs px-2 py-1 rounded-full">
+          High Confidence
+        </div>
+      )}
       <div className="flex justify-center items-center gap-6 mb-4">
-        <h2 className="text-2xl font-semibold text-dashYellow">Founder&apos;s Edge Checklist</h2>
+        <h2 className="text-2xl font-semibold">Founder&apos;s Edge Checklist</h2>
         <div className="bg-dashYellow text-black px-3 py-1 rounded-full text-sm font-semibold shadow flex items-center">
           <span>
             Score: <span className="font-bold">{score}</span> / 100
@@ -50,16 +70,16 @@ export function FoundersEdgeChecklist({ data, showLegend = false }: ChecklistPro
         </div>
       </div>
       <p className="text-base opacity-80 mb-6 text-center">Signal-based checklist of founder credibility and product traction.</p>
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
         {canonicalChecklist.map((label) => {
           const raw = data[label];
-          const val = valueToScore(raw, (gradeMaps as any)[label]);
+          const status = getStatus(raw, label);
           return (
             <div
               key={label}
-              className="flex items-center gap-2 bg-zinc-800 rounded-full px-4 py-3"
+              className="flex items-center gap-2 bg-zinc-800 rounded-full px-3 py-1 text-sm text-white"
             >
-              {getIcon(val)}
+              {getIcon(status)}
               <span className="text-base">{label}</span>
             </div>
           );
@@ -67,7 +87,7 @@ export function FoundersEdgeChecklist({ data, showLegend = false }: ChecklistPro
       </div>
       {showLegend && (
         <div className="mt-4 flex items-center gap-4 text-sm">
-          <div className="flex items-center gap-1"><MinusCircle className="text-yellow-400 w-4 h-4" /> Unknown</div>
+          <div className="flex items-center gap-1"><Circle className="text-yellow-400 w-4 h-4 fill-yellow-400" /> Unknown</div>
           <div className="flex items-center gap-1"><XCircle className="text-red-500 w-4 h-4" /> No</div>
           <div className="flex items-center gap-1"><CheckCircle className="text-green-500 w-4 h-4" /> Yes</div>
         </div>

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -36,6 +36,9 @@ export function Navbar({ dashcStats }: NavbarProps) {
             <NavLink href="/creator-wallets" active={pathname === "/creator-wallets"}>
               Creator Wallets
             </NavLink>
+            <NavLink href="/founders-edge" active={pathname === "/founders-edge"}>
+              Founder's Edge
+            </NavLink>
             <NavLink href="/founder-interviews" active={pathname === "/founder-interviews"}>
               Founder Interviews
             </NavLink>
@@ -56,6 +59,9 @@ export function Navbar({ dashcStats }: NavbarProps) {
           </NavLink>
           <NavLink href="/creator-wallets" active={pathname === "/creator-wallets"}>
             Creator Wallets
+          </NavLink>
+          <NavLink href="/founders-edge" active={pathname === "/founders-edge"}>
+            Founder's Edge
           </NavLink>
           <NavLink href="/founder-interviews" active={pathname === "/founder-interviews"}>
             Founder Interviews

--- a/components/token-card.tsx
+++ b/components/token-card.tsx
@@ -4,7 +4,15 @@ import { formatCurrency0 } from "@/lib/utils"
 import { canonicalChecklist } from "@/components/founders-edge-checklist"
 import { valueToScore } from "@/lib/score"
 import {
-  User, Twitter, Clock, Medal, Package, Layers, TrendingUp, Users
+  User,
+  Twitter,
+  Clock,
+  Medal,
+  Package,
+  Layers,
+  TrendingUp,
+  Users,
+  Link as LinkIcon,
 } from "lucide-react"
 import Link from "next/link"
 import { FileSearch } from "lucide-react"
@@ -18,6 +26,7 @@ const checklistIcons: Record<string, JSX.Element> = {
   "Funding Status": <TrendingUp className="h-4 w-4" />,
   "Token-Product Integration Depth": <Layers className="h-4 w-4" />,
   "Social Reach & Engagement Index": <Users className="h-4 w-4" />,
+  "Data Integration": <LinkIcon className="h-4 w-4" />,
 }
 
 function badgeColor(value: any): string {

--- a/components/token-table.tsx
+++ b/components/token-table.tsx
@@ -20,6 +20,7 @@ import {
   Package,
   Layers,
   TrendingUp,
+  Link as LinkIcon,
 } from "lucide-react"
 import {
   Tooltip,
@@ -46,6 +47,7 @@ const checklistIcons: Record<string, JSX.Element> = {
   "Funding Status": <TrendingUp className="h-4 w-4" />,
   "Token-Product Integration Depth": <Layers className="h-4 w-4" />,
   "Social Reach & Engagement Index": <Users className="h-4 w-4" />,
+  "Data Integration": <LinkIcon className="h-4 w-4" />,
 }
 
 interface ResearchScoreData {


### PR DESCRIPTION
## Summary
- redesign Founder's Edge checklist component
- add Data Integration trait and color mapping
- fetch the extra trait from Google Sheets
- include new Founder's Edge nav link and homepage link
- create `/founders-edge` page
- add test for Google Sheet parsing

## Testing
- `npm test` *(fails: Cannot find module /workspace/Dashcoin/app/actions/googlesheet-action imported from /workspace/Dashcoin/__tests__/googlesheet-action.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_683fcdce65cc832ca52121640fe49496