### PR TITLE
Increase token card green

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -119,14 +119,15 @@
 /* Token card gradient styling */
 .token-card {
   background-color: #f9f9f6;
-  background-image: linear-gradient(180deg, #f9f9f6, #eefbf3);
+  /* increase green intensity while keeping gradient */
+  background-image: linear-gradient(180deg, #f9f9f6, #d4f4e4);
   border-radius: 0.5rem;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
   transition: transform 0.2s ease, background-image 0.2s ease, box-shadow 0.2s ease;
 }
 .token-card:hover {
   transform: translateY(-2px);
-  background-image: linear-gradient(180deg, #f9f9f6, #e5f6ea);
+  background-image: linear-gradient(180deg, #f9f9f6, #c1ecd6);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
 }
 


### PR DESCRIPTION
## Summary
- tune the gradient for `.token-card` to intensify the green

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fd2c93128832ca1a38fffe00a35c1