### PR TITLE
Fix Dexscreener fetch delay

### DIFF
--- a/components/token-search-list.tsx
+++ b/components/token-search-list.tsx
@@ -54,7 +54,6 @@ export default function TokenSearchList() {
         const res = await fetch("/api/tokens");
         const data = await res.json();
         setTokens(data || []);
-        fetchDexData(data || []);
       } catch (err) {
         console.error("Error fetching tokens", err);
       } finally {
@@ -62,7 +61,7 @@ export default function TokenSearchList() {
       }
     }
     loadTokens();
-  }, [fetchDexData]);
+  }, []);
 
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- stop fetching Dexscreener data for all tokens on page load

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fd3ac9468832cb69cd7125838321f