### PR TITLE
UI improvements for founder edge checklist

### DIFF
--- a/app/actions/googlesheet-action.ts
+++ b/app/actions/googlesheet-action.ts
@@ -40,7 +40,7 @@ export async function fetchTokenResearch(): Promise<ResearchScoreData[]> {
 
     return structured.map((entry: any) => {
       const result: Record<string, any> = {
-        symbol: (entry['Project'] || '').toString().toUpperCase(),
+        symbol: (entry['Project'] || '').toString().trim().toUpperCase(),
         score:
           entry['Score'] !== undefined && entry['Score'] !== ''
             ? parseFloat(entry['Score'])

--- a/app/api/research/[symbol]/route.ts
+++ b/app/api/research/[symbol]/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import { fetchTokenResearch } from '@/app/actions/googlesheet-action';
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { symbol: string } }
+) {
+  try {
+    const all = await fetchTokenResearch();
+    const symbol = params.symbol.toUpperCase();
+    const entry = all.find(r => r.symbol.toUpperCase() === symbol);
+    if (!entry) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    }
+    return NextResponse.json(entry);
+  } catch (err) {
+    console.error('Error fetching research:', err);
+    return NextResponse.json({ error: 'Failed to fetch' }, { status: 500 });
+  }
+}

--- a/components/founders-edge-checklist.tsx
+++ b/components/founders-edge-checklist.tsx
@@ -33,12 +33,9 @@ interface ChecklistProps {
 export function FoundersEdgeChecklist({ data, showLegend = false }: ChecklistProps) {
   if (!data) return null;
   const score = Number(data["Score"]) || 0;
-  const borderColor =
-    score >= 70 ? "border-green-500" : score >= 40 ? "border-yellow-500" : "border-red-500";
-
   return (
     <DashcoinCard
-      className={`token-card relative p-10 rounded-2xl shadow-lg border-2 ${borderColor}`}
+      className="token-card relative p-10 rounded-2xl shadow-lg"
     >
       <div className="flex justify-center items-center gap-6 mb-4">
         <h2 className="text-2xl font-semibold text-dashYellow">Founder&apos;s Edge Checklist</h2>
@@ -57,7 +54,7 @@ export function FoundersEdgeChecklist({ data, showLegend = false }: ChecklistPro
           return (
             <div
               key={label}
-              className="flex items-center gap-2 bg-zinc-800 rounded-full px-4 py-3"
+              className="flex items-center gap-2 bg-white text-black rounded-full px-4 py-3"
             >
               {getIcon(val)}
               <span className="text-base">{label}</span>

--- a/components/founders-edge-checklist.tsx
+++ b/components/founders-edge-checklist.tsx
@@ -38,7 +38,7 @@ export function FoundersEdgeChecklist({ data, showLegend = false }: ChecklistPro
 
   return (
     <DashcoinCard
-      className={`relative bg-zinc-900 p-10 rounded-2xl shadow-lg ${borderColor}`}
+      className={`token-card relative p-10 rounded-2xl shadow-lg border-2 ${borderColor}`}
     >
       <div className="flex justify-center items-center gap-6 mb-4">
         <h2 className="text-2xl font-semibold text-dashYellow">Founder&apos;s Edge Checklist</h2>


### PR DESCRIPTION
## Summary
- apply token-card gradient styling to `FoundersEdgeChecklist`
- add API route to get research data for a token
- load checklist data from the API route on token detail page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fd5b49d00832cae85798d41b7e5ad