### PR TITLE
Fix founder edge checklist

### DIFF
--- a/components/founders-edge-checklist.tsx
+++ b/components/founders-edge-checklist.tsx
@@ -1,7 +1,7 @@
 import { DashcoinCard } from "@/components/ui/dashcoin-card";
 import { CheckCircle, XCircle, MinusCircle } from "lucide-react";
 import React from "react";
-import { gradeMaps, valueToScore } from "@/lib/score";
+import { gradeMaps, valueToScore, computeFounderScore } from "@/lib/score";
 
 export const canonicalChecklist = [
   "Team Doxxed",
@@ -32,16 +32,17 @@ interface ChecklistProps {
 
 export function FoundersEdgeChecklist({ data, showLegend = false }: ChecklistProps) {
   if (!data) return null;
-  const score = Number(data["Score"]) || 0;
+  const sheetScore = Number(data["Score"]);
+  const score = !isNaN(sheetScore) && sheetScore > 0 ? sheetScore : computeFounderScore(data);
   return (
     <DashcoinCard
       className="token-card relative p-10 rounded-2xl shadow-lg"
     >
       <div className="flex justify-center items-center gap-6 mb-4">
         <h2 className="text-2xl font-semibold text-dashYellow">Founder&apos;s Edge Checklist</h2>
-        <div className="bg-dashYellow text-black px-3 py-1 rounded-full text-sm font-semibold shadow flex items-center">
+        <div className="bg-dashGreen text-white px-3 py-1 rounded-full text-sm font-semibold shadow flex items-center">
           <span>
-            Score: <span className="font-bold">{score}</span> / 100
+            Founder Score: <span className="font-bold">{score}</span> / 100
           </span>
           {score >= 75 && <span className="ml-2 animate-bounce">🐸</span>}
         </div>

--- a/lib/score.js
+++ b/lib/score.js
@@ -11,6 +11,61 @@ export const gradeMaps = {
     Unknown: 0,
     '': 0,
   },
+  'Team Doxxed': {
+    'Legal Names': 2,
+    Pseudonymous: 1,
+    Unknown: 0,
+    '': 0,
+  },
+  'Twitter Activity Level': {
+    High: 2,
+    Medium: 1,
+    Low: 0,
+    Unknown: 0,
+    '': 0,
+  },
+  'Time Commitment': {
+    'Full-time (≥ 35 hrs/wk)': 2,
+    'Part-time / side-project': 1,
+    Abandoned: 0,
+    Unknown: 0,
+    '': 0,
+  },
+  'Prior Founder Experience': {
+    'Two or more prior startups': 2,
+    'One prior startup': 1,
+    None: 0,
+    Unknown: 0,
+    '': 0,
+  },
+  'Product Maturity': {
+    'Revenue-positive / paying customers': 2,
+    'Live MVP': 1,
+    'Prototype / pre-alpha': 0,
+    Unknown: 0,
+    '': 0,
+  },
+  'Funding Status': {
+    'Venture Backed': 2,
+    'Angel Investors': 1,
+    Bootstrapped: 0,
+    Unknown: 0,
+    '': 0,
+  },
+  'Token-Product Integration Depth': {
+    'Fully live': 2,
+    'Concept only (white-paper / roadmap)': 1,
+    None: 0,
+    Unknown: 0,
+    '': 0,
+  },
+  'Social Reach & Engagement Index': {
+    'High ( ≥ 20 k followers )': 2,
+    'Medium ( 5 k – 20 k followers )': 1,
+    'Low ( < 5 k followers )': 0,
+    Unknown: 0,
+    '': 0,
+  },
 };
 
 export function valueToScore(value, map = gradeMaps.default) {

--- a/lib/score.js
+++ b/lib/score.js
@@ -83,3 +83,15 @@ export function valueToScore(value, map = gradeMaps.default) {
   const num = parseInt(key, 10);
   return isNaN(num) ? 0 : num;
 }
+
+export function computeFounderScore(data) {
+  if (!data) return 0;
+  const traits = Object.keys(gradeMaps).filter(k => k !== 'default');
+  let total = 0;
+  for (const label of traits) {
+    const raw = data[label];
+    total += valueToScore(raw, gradeMaps[label]);
+  }
+  const max = traits.length * 2;
+  return Math.round((total / max) * 100);
+}


### PR DESCRIPTION
## Summary
- add grade maps for each founder edge trait so that the checklist can show Yes/No values instead of Unknown

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fdcda1458832cb55e1241d1f47f9c