### PR TITLE
Implement radar chart in token cards

### DIFF
--- a/components/token-card.tsx
+++ b/components/token-card.tsx
@@ -1,32 +1,9 @@
 import { DashcoinCard } from "@/components/ui/dashcoin-card"
-import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from "@/components/ui/tooltip"
 
 import AnimatedMarketCap from "@/components/animated-marketcap"
-import { canonicalChecklist } from "@/components/founders-edge-checklist"
-import { valueToScore } from "@/lib/score"
-import {
-  User, Twitter, Clock, Medal, Package, Layers, TrendingUp, Users
-} from "lucide-react"
+import { TraitsRadarChart } from "./traits-radar-chart"
 import Link from "next/link"
 import { FileSearch } from "lucide-react"
-
-const checklistIcons: Record<string, JSX.Element> = {
-  "Team Doxxed": <User className="h-4 w-4" />,
-  "Twitter Activity Level": <Twitter className="h-4 w-4" />,
-  "Time Commitment": <Clock className="h-4 w-4" />,
-  "Prior Founder Experience": <Medal className="h-4 w-4" />,
-  "Product Maturity": <Package className="h-4 w-4" />,
-  "Funding Status": <TrendingUp className="h-4 w-4" />,
-  "Token-Product Integration Depth": <Layers className="h-4 w-4" />,
-  "Social Reach & Engagement Index": <Users className="h-4 w-4" />,
-}
-
-function badgeColor(value: any): string {
-  const score = valueToScore(value)
-  if (score === 2) return "bg-green-600 text-white"
-  if (score === 1) return "bg-yellow-600 text-black"
-  return "bg-gray-600 text-white"
-}
 
 export interface TokenCardProps {
   token: Record<string, any>
@@ -74,24 +51,7 @@ export function TokenCard({ token, researchScore }: TokenCardProps) {
 
       <div>
         <p className="text-base font-medium mb-2 text-dashYellow">Traits</p>
-        <div className="flex flex-wrap gap-1.5">
-          {canonicalChecklist.map(label => {
-            const value = (token as any)[label]
-            return (
-              <TooltipProvider delayDuration={0} key={label}>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span className={`flex items-center gap-1 px-2 py-0.5 rounded ${badgeColor(value)} text-sm`}>
-                      {checklistIcons[label]}
-                      <span>{value || '-'}</span>
-                    </span>
-                  </TooltipTrigger>
-                  <TooltipContent>{label}</TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            )
-          })}
-        </div>
+        <TraitsRadarChart token={token} />
       </div>
 
         <div className="flex justify-end mt-auto">

--- a/components/traits-radar-chart.tsx
+++ b/components/traits-radar-chart.tsx
@@ -1,0 +1,32 @@
+import {
+  RadarChart,
+  PolarGrid,
+  PolarAngleAxis,
+  PolarRadiusAxis,
+  Radar,
+  ResponsiveContainer,
+} from 'recharts'
+import { canonicalChecklist } from '@/components/founders-edge-checklist'
+import { gradeMaps, valueToScore } from '@/lib/score'
+
+export function TraitsRadarChart({ token }: { token: Record<string, any> }) {
+  const data = canonicalChecklist.map(label => {
+    const raw = (token as any)[label]
+    const score = valueToScore(raw, (gradeMaps as any)[label] || gradeMaps.default)
+    const val = score === 2 ? 3 : score === 1 ? 1 : 2
+    return { trait: label, value: val }
+  })
+
+  return (
+    <div className="w-full h-64">
+      <ResponsiveContainer width="100%" height="100%">
+        <RadarChart data={data} outerRadius="80%">
+          <PolarGrid stroke="#d1d5db" />
+          <PolarAngleAxis dataKey="trait" tick={{ fill: '#111111', fontSize: 10 }} />
+          <PolarRadiusAxis angle={90} domain={[0, 3]} tick={false} />
+          <Radar dataKey="value" stroke="#00C851" fill="#00C851" fillOpacity={0.4} />
+        </RadarChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add TraitsRadarChart using Recharts RadarChart
- replace token trait badges with radar graph

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683fe3d2032c832cbc0ccd705135ed51