### PR TITLE
Implement progress bars for founder traits

### DIFF
--- a/components/founders-edge-checklist.tsx
+++ b/components/founders-edge-checklist.tsx
@@ -3,6 +3,17 @@ import { CheckCircle, XCircle, MinusCircle } from "lucide-react";
 import React from "react";
 import { gradeMaps, valueToScore, computeFounderScore } from "@/lib/score";
 
+function barColor(score: number) {
+  if (score === 2) return "bg-green-500";
+  if (score === 1) return "bg-yellow-500";
+  return "bg-red-500";
+}
+
+function overallColor(score: number) {
+  if (score >= 70) return "bg-green-500";
+  if (score >= 40) return "bg-yellow-500";
+  return "bg-red-500";
+}
 export const canonicalChecklist = [
   "Team Doxxed",
   "Twitter Activity Level",
@@ -13,17 +24,6 @@ export const canonicalChecklist = [
   "Token-Product Integration Depth",
   "Social Reach & Engagement Index",
 ];
-
-function getIcon(value: number) {
-  switch (value) {
-    case 2:
-      return <CheckCircle className="text-green-500 w-5 h-5" />;
-    case 1:
-      return <XCircle className="text-red-500 w-5 h-5" />;
-    default:
-      return <MinusCircle className="text-yellow-400 w-5 h-5" />;
-  }
-}
 
 interface ChecklistProps {
   data: Record<string, any>;
@@ -48,20 +48,27 @@ export function FoundersEdgeChecklist({ data, showLegend = false }: ChecklistPro
         </div>
       </div>
       <p className="text-base opacity-80 mb-6 text-center">Signal-based checklist of founder credibility and product traction.</p>
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-        {canonicalChecklist.map((label) => {
-          const raw = data[label];
-          const val = valueToScore(raw, (gradeMaps as any)[label]);
-          return (
-            <div
-              key={label}
-              className="flex items-center gap-2 bg-white text-black rounded-full px-4 py-3"
-            >
-              {getIcon(val)}
-              <span className="text-base">{label}</span>
-            </div>
-          );
-        })}
+      <div className="space-y-3">
+        {[{ label: "Founder Score", value: score, overall: true },
+          ...canonicalChecklist.map(label => ({
+            label,
+            value: valueToScore(data[label], (gradeMaps as any)[label]),
+            overall: false,
+          }))].map(({ label, value, overall }) => {
+            const barValue = overall ? Math.max(0, Math.min(100, Number(value))) : value * 50;
+            const color = overall ? overallColor(barValue) : barColor(value);
+            return (
+              <div key={label} className="flex items-center gap-4">
+                <span className="w-48 text-sm font-medium text-dashYellow">{label}</span>
+                <div className="flex-1 bg-gray-200 rounded h-3 overflow-hidden">
+                  <div
+                    className={`h-3 ${color} rounded transition-all duration-700`}
+                    style={{ width: `${barValue}%` }}
+                  />
+                </div>
+              </div>
+            );
+          })}
       </div>
       {showLegend && (
         <div className="mt-4 flex items-center gap-4 text-sm">


### PR DESCRIPTION
## Summary
- transform Founder’s Edge traits into progress bars
- color bars green/yellow/red based on value
- include overall founder score as first bar

## Testing
- `npm test`
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fe3d7ec60832c9dee6ce1fec403ee