### PR TITLE
Add trait description tooltips

### DIFF
--- a/components/founder-metadata-grid.tsx
+++ b/components/founder-metadata-grid.tsx
@@ -1,6 +1,7 @@
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { canonicalChecklist } from "@/components/founders-edge-checklist";
 import { gradeMaps, valueToScore } from "@/lib/score";
+import { traitDescriptions } from "@/data/trait-descriptions";
 
 interface ResearchData {
   symbol: string;
@@ -58,7 +59,7 @@ export function FounderMetadataGrid({ token1, token2 }: Props) {
                 <TooltipTrigger asChild>
                   <div className="px-2 font-medium cursor-help">{label}</div>
                 </TooltipTrigger>
-                <TooltipContent>{label}</TooltipContent>
+                <TooltipContent>{traitDescriptions[label]}</TooltipContent>
               </Tooltip>
             </TooltipProvider>
             <div className={`px-2 text-center rounded-md ${col1} ${classBest1} group-hover:bg-dashGreen-light/20`}>{val1 || '-'}</div>

--- a/components/founders-edge-checklist.tsx
+++ b/components/founders-edge-checklist.tsx
@@ -2,6 +2,8 @@ import { DashcoinCard } from "@/components/ui/dashcoin-card";
 import { CheckCircle, XCircle, MinusCircle } from "lucide-react";
 import React from "react";
 import { gradeMaps, valueToScore, computeFounderScore } from "@/lib/score";
+import { traitDescriptions } from "@/data/trait-descriptions";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 
 export const canonicalChecklist = [
   "Team Doxxed",
@@ -53,13 +55,17 @@ export function FoundersEdgeChecklist({ data, showLegend = false }: ChecklistPro
           const raw = data[label];
           const val = valueToScore(raw, (gradeMaps as any)[label]);
           return (
-            <div
-              key={label}
-              className="flex items-center gap-2 bg-white text-black rounded-full px-4 py-3"
-            >
-              {getIcon(val)}
-              <span className="text-base">{label}</span>
-            </div>
+            <TooltipProvider delayDuration={0} key={label}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <div className="flex items-center gap-2 bg-white text-black rounded-full px-4 py-3 cursor-help">
+                    {getIcon(val)}
+                    <span className="text-base">{label}</span>
+                  </div>
+                </TooltipTrigger>
+                <TooltipContent>{traitDescriptions[label]}</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           );
         })}
       </div>

--- a/components/token-card.tsx
+++ b/components/token-card.tsx
@@ -1,5 +1,6 @@
 import { DashcoinCard } from "@/components/ui/dashcoin-card"
 import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from "@/components/ui/tooltip"
+import { traitDescriptions } from "@/data/trait-descriptions"
 
 import AnimatedMarketCap from "@/components/animated-marketcap"
 import { canonicalChecklist } from "@/components/founders-edge-checklist"
@@ -86,7 +87,7 @@ export function TokenCard({ token, researchScore }: TokenCardProps) {
                       <span>{value || '-'}</span>
                     </span>
                   </TooltipTrigger>
-                  <TooltipContent>{label}</TooltipContent>
+                  <TooltipContent>{traitDescriptions[label]}</TooltipContent>
                 </Tooltip>
               </TooltipProvider>
             )

--- a/components/token-table.tsx
+++ b/components/token-table.tsx
@@ -35,6 +35,7 @@ import { useCallback } from "react"
 import { fetchTokenResearch } from "@/app/actions/googlesheet-action"
 import { canonicalChecklist } from "@/components/founders-edge-checklist"
 import { researchFilterOptions } from "@/data/research-filter-options"
+import { traitDescriptions } from "@/data/trait-descriptions"
 import { useRouter, useSearchParams } from "next/navigation"
 
 const checklistIcons: Record<string, JSX.Element> = {
@@ -465,7 +466,7 @@ export default function TokenTable({ data }: { data: PaginatedTokenResponse | To
                             {checklistIcons[label]}
                           </div>
                         </TooltipTrigger>
-                        <TooltipContent>{label}</TooltipContent>
+                        <TooltipContent>{traitDescriptions[label]}</TooltipContent>
                       </Tooltip>
                     </TooltipProvider>
                     <Filter

--- a/data/trait-descriptions.ts
+++ b/data/trait-descriptions.ts
@@ -1,0 +1,18 @@
+export const traitDescriptions: Record<string, string> = {
+  "Team Doxxed":
+    "Whether the founders are publicly identified. Yes = legal names are disclosed. No = founders use pseudonyms. Unknown if identity info isn't available.",
+  "Twitter Activity Level":
+    "How active the official Twitter account is. Yes = high activity, No = medium activity, Unknown = low or no activity.",
+  "Time Commitment":
+    "How much time the team dedicates to the project. Yes = full-time (\u2265 35 hrs/week), No = part-time or side project, Unknown = abandoned or not specified.",
+  "Prior Founder Experience":
+    "Whether the founders previously built startups. Yes = two or more prior startups, No = one prior startup, Unknown = none or unclear.",
+  "Product Maturity":
+    "Current stage of the product. Yes = revenue-positive with paying customers, No = live MVP, Unknown = prototype or unspecified.",
+  "Funding Status":
+    "Level of outside investment. Yes = venture backed, No = angel investors, Unknown = bootstrapped or undisclosed.",
+  "Token-Product Integration Depth":
+    "How fully the token is integrated with the product. Yes = token is fully live, No = concept only, Unknown = none or not stated.",
+  "Social Reach & Engagement Index":
+    "Community size and engagement. Yes = high (\u2265 20k followers), No = medium (5k–20k), Unknown = low (<5k) or not known.",
+};


### PR DESCRIPTION
## Summary
- create `trait-descriptions` data map
- show description tooltips in `FoundersEdgeChecklist`
- show description tooltips in comparison grid, token card, and token table

## Testing
- `npm test`
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fe41ca16c832c804efd987a632df2