### PR TITLE
Add link to analyst group in navbar

### DIFF
--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -42,6 +42,9 @@ export function Navbar({ dashcStats }: NavbarProps) {
             <NavLink href="https://dashcoin-research.gitbook.io/dashcoin-research" active={false} external>
               Founder's Guide
             </NavLink>
+            <NavLink href="https://dashcoin-research-tg-gated.vercel.app/" active={false} external>
+              Join the Dashcoin Analyst Group
+            </NavLink>
           </nav>
         </div>
       </div>
@@ -62,6 +65,9 @@ export function Navbar({ dashcStats }: NavbarProps) {
           </NavLink>
           <NavLink href="https://dashcoin-research.gitbook.io/dashcoin-research" active={false} external>
             Founder's Guide
+          </NavLink>
+          <NavLink href="https://dashcoin-research-tg-gated.vercel.app/" active={false} external>
+            Join the Dashcoin Analyst Group
           </NavLink>
           </nav>
       </div>


### PR DESCRIPTION
## Summary
- link to the Dashcoin Analyst Group from navigation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68407a2f6720832cae669bf6205f408b