### PR TITLE
Improve token lookup by name

### DIFF
--- a/app/actions/googlesheet-action.ts
+++ b/app/actions/googlesheet-action.ts
@@ -2,6 +2,7 @@ import { gradeMaps, valueToScore } from '@/lib/score'
 
 interface ResearchScoreData {
   symbol: string
+  project: string
   score: number | null
   [key: string]: any
 }
@@ -53,8 +54,16 @@ export async function fetchTokenResearch(): Promise<ResearchScoreData[]> {
         });
         score = Math.round((total / (traits.length * 2)) * 100);
       }
+      const project = (entry['Project'] || '').toString().trim();
+      const rawSymbol =
+        entry['Symbol'] ||
+        entry['Ticker'] ||
+        entry['Token Symbol'] ||
+        entry['Symbol/Ticker'] ||
+        project;
       const result: Record<string, any> = {
-        symbol: (entry['Project'] || '').toString().trim().toUpperCase(),
+        symbol: rawSymbol.toString().trim().toUpperCase(),
+        project,
         score,
       };
       [

--- a/app/api/research/[symbol]/route.ts
+++ b/app/api/research/[symbol]/route.ts
@@ -2,13 +2,24 @@ import { NextResponse } from 'next/server';
 import { fetchTokenResearch } from '@/app/actions/googlesheet-action';
 
 export async function GET(
-  _req: Request,
+  req: Request,
   { params }: { params: { symbol: string } }
 ) {
   try {
     const all = await fetchTokenResearch();
     const symbol = params.symbol.toUpperCase();
-    const entry = all.find(r => r.symbol.toUpperCase() === symbol);
+    const { searchParams } = new URL(req.url);
+    const name = searchParams.get('name') || undefined;
+    const matches = all.filter(r => r.symbol.toUpperCase() === symbol);
+    if (matches.length === 0) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    }
+    let entry = matches[0];
+    if (name && matches.length > 1) {
+      const lower = name.toLowerCase();
+      const found = matches.find(m => (m.project || '').toLowerCase() === lower);
+      if (found) entry = found;
+    }
     if (!entry) {
       return NextResponse.json({ error: 'Not found' }, { status: 404 });
     }

--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -10,6 +10,7 @@ import { DashcoinLogo } from "@/components/dashcoin-logo";
 import { SimpleGrowthCard } from "@/components/simple-growth-card";
 import { FounderMetadataGrid } from "@/components/founder-metadata-grid";
 import { fetchTokenResearch } from "@/app/actions/googlesheet-action";
+import { findResearchEntry } from "@/lib/utils";
 
 import { BarChart as RechartsBarChart, Bar, XAxis, YAxis, Tooltip, Legend, ResponsiveContainer } from 'recharts';
 
@@ -37,6 +38,7 @@ interface ComparisonTokenData {
 
 interface ResearchScoreData {
   symbol: string;
+  project: string;
   score: number | null;
   [key: string]: any;
 }
@@ -181,8 +183,12 @@ export default function ComparePage() {
       if (topTwo.length === 2) {
         const token1Data = convertTokenData(topTwo[0]);
         const token2Data = convertTokenData(topTwo[1]);
-        const r1 = researchData.find(r => r.symbol.toUpperCase() === (topTwo[0].symbol || '').toUpperCase()) || null;
-        const r2 = researchData.find(r => r.symbol.toUpperCase() === (topTwo[1].symbol || '').toUpperCase()) || null;
+        const r1 =
+          findResearchEntry(researchData, topTwo[0].symbol || '', topTwo[0].name || '') ||
+          null;
+        const r2 =
+          findResearchEntry(researchData, topTwo[1].symbol || '', topTwo[1].name || '') ||
+          null;
 
         setToken1Name(topTwo[0].token);
         setToken2Name(topTwo[1].token);
@@ -233,8 +239,18 @@ export default function ComparePage() {
   // When research data loads or comparison tokens change, update the metadata
   useEffect(() => {
     if (!comparisonData.token1 || !comparisonData.token2 || researchData.length === 0) return;
-    const r1 = researchData.find(r => r.symbol.toUpperCase() === (comparisonData.token1?.symbol || '').toUpperCase()) || null;
-    const r2 = researchData.find(r => r.symbol.toUpperCase() === (comparisonData.token2?.symbol || '').toUpperCase()) || null;
+    const r1 =
+      findResearchEntry(
+        researchData,
+        comparisonData.token1?.symbol || '',
+        comparisonData.token1?.name || '',
+      ) || null;
+    const r2 =
+      findResearchEntry(
+        researchData,
+        comparisonData.token2?.symbol || '',
+        comparisonData.token2?.name || '',
+      ) || null;
     setComparisonResearch({ token1: r1, token2: r2 });
   }, [researchData, comparisonData]);
 
@@ -270,8 +286,12 @@ export default function ComparePage() {
       console.log('TOKEN! ---------------------------->', token1Data)
       console.log("TOKEN2---------------->", token2Data);
 
-      const r1 = researchData.find(r => r.symbol.toUpperCase() === (token1.symbol || '').toUpperCase()) || null;
-      const r2 = researchData.find(r => r.symbol.toUpperCase() === (token2.symbol || '').toUpperCase()) || null;
+      const r1 =
+        findResearchEntry(researchData, token1.symbol || '', token1.name || '') ||
+        null;
+      const r2 =
+        findResearchEntry(researchData, token2.symbol || '', token2.name || '') ||
+        null;
       setComparisonData({ token1: token1Data, token2: token2Data });
       setComparisonResearch({ token1: r1, token2: r2 });
       setIsComparing(true);

--- a/app/tokendetail/[symbol]/page.tsx
+++ b/app/tokendetail/[symbol]/page.tsx
@@ -48,9 +48,11 @@ interface TokenResearchData {
 
 async function fetchTokenResearchClient(
   tokenSymbol: string,
+  tokenName: string,
 ): Promise<TokenResearchData | null> {
   try {
-    const res = await fetch(`/api/research/${tokenSymbol}`);
+    const encoded = encodeURIComponent(tokenName);
+    const res = await fetch(`/api/research/${tokenSymbol}?name=${encoded}`);
     if (!res.ok) return null;
     const data = await res.json();
     return data;
@@ -110,7 +112,7 @@ export default function TokenResearchPage({
     const getResearchData = async () => {
       setIsLoading(true);
       try {
-        const data = await fetchTokenResearchClient(symbol);
+        const data = await fetchTokenResearchClient(symbol, tokenData?.name || '');
         setResearchData(data);
         setHasScore(!!data && !!data["Score"]);
       } catch (error) {
@@ -121,7 +123,7 @@ export default function TokenResearchPage({
     };
 
     getResearchData();
-  }, [symbol]);
+  }, [symbol, tokenData]);
 
   useEffect(() => {
     async function loadData() {

--- a/components/token-card-list.tsx
+++ b/components/token-card-list.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from "react"
 import { batchFetchTokensData } from "@/app/actions/dexscreener-actions"
 import { fetchTokenResearch } from "@/app/actions/googlesheet-action"
+import { findResearchEntry } from "@/lib/utils"
 import type { TokenData, PaginatedTokenResponse } from "@/types/dune"
 import { TokenCard } from "./token-card"
 import { DashcoinCard } from "@/components/ui/dashcoin-card"
@@ -10,6 +11,7 @@ import { Loader2 } from "lucide-react"
 
 interface ResearchScoreData {
   symbol: string
+  project: string
   score: number | null
   [key: string]: any
 }
@@ -59,12 +61,12 @@ export default function TokenCardList({ data }: { data: PaginatedTokenResponse |
     fetchDex(tokens)
   }, [tokens, fetchDex])
 
-  const getResearch = (symbol: string): ResearchScoreData | undefined =>
-    researchScores.find(r => r.symbol.toUpperCase() === symbol.toUpperCase())
+  const getResearch = (symbol: string, name: string): ResearchScoreData | undefined =>
+    findResearchEntry(researchScores, symbol, name)
 
   const tokensWithData = tokens.map(t => {
     const dex = dexscreenerData[t.token] || {}
-    const research = getResearch(t.symbol || "") || {}
+    const research = getResearch(t.symbol || "", t.name || "") || {}
     return { ...t, ...dex, ...research, marketCap: dex.marketCap ?? t.marketCap }
   })
 

--- a/components/token-search-list.tsx
+++ b/components/token-search-list.tsx
@@ -12,11 +12,12 @@ import { DashcoinCard } from "@/components/ui/dashcoin-card";
 import { Loader2, LayoutGrid, Table as TableIcon } from "lucide-react";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { DashcoinButton } from "@/components/ui/dashcoin-button";
-import { formatCurrency0 } from "@/lib/utils";
+import { formatCurrency0, findResearchEntry } from "@/lib/utils";
 import AnimatedMarketCap from "@/components/animated-marketcap";
 
 interface ResearchScoreData {
   symbol: string;
+  project: string;
   score: number | null;
   [key: string]: any;
 }
@@ -108,8 +109,7 @@ export default function TokenSearchList() {
   const tokensWithData = useMemo(() => {
     return tokens.map(t => {
       const sym = (t.symbol || '').toUpperCase();
-      const research =
-        researchScores.find(r => r.symbol.toUpperCase() === sym) || {};
+      const research = findResearchEntry(researchScores, sym, t.name || '') || {};
       const dex = dexscreenerData[t.token] || {};
       const wallet = walletInfo[sym] || { walletLink: '', twitter: '' };
       return {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -108,3 +108,25 @@ export function hexToRgba(hex: string, alpha: number): string {
   const b = bigint & 255
   return `rgba(${r}, ${g}, ${b}, ${alpha})`
 }
+
+export interface ResearchEntry {
+  symbol: string
+  project?: string
+  [key: string]: any
+}
+
+export function findResearchEntry(
+  research: ResearchEntry[],
+  symbol: string,
+  name?: string,
+): ResearchEntry | undefined {
+  const sym = symbol.toUpperCase()
+  const matches = research.filter(r => (r.symbol || '').toUpperCase() === sym)
+  if (matches.length <= 1) return matches[0]
+  if (name) {
+    const lower = name.toLowerCase()
+    const found = matches.find(m => (m.project || '').toLowerCase() === lower)
+    if (found) return found
+  }
+  return matches[0]
+}


### PR DESCRIPTION
## Summary
- parse Google Sheet rows with explicit `project` name and symbol
- add utility to resolve duplicate research entries
- support optional name parameter in the research API
- match research info using project name where available

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684128926c4c832cbc23a290da5d357e