### PR TITLE
Add token logos and banner

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -337,8 +337,9 @@ export default async function Home() {
                 href={dashcoinTradeLink}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="group flex items-center gap-2 px-8 py-4 bg-gradient-to-r from-teal-600 to-teal-600 hover:from-teal-500 hover:to-green-500 text-white font-semibold rounded-xl transition-all duration-300 transform hover:scale-105 shadow-lg hover:shadow-xl"
+                className="relative group flex items-center gap-2 px-8 py-4 bg-gradient-to-r from-teal-600 to-teal-600 hover:from-teal-500 hover:to-green-500 text-white font-semibold rounded-xl transition-all duration-300 transform hover:scale-105 shadow-lg hover:shadow-xl"
               >
+                <span className="absolute -top-2 -right-2 bg-amber-500 text-xs font-semibold px-2 py-0.5 rounded-full">Coming Soon</span>
                 <span>Download Chrome Extension</span>
                 <Chrome className="w-5 h-5 group-hover:translate-x-0.5 group-hover:-translate-y-0.5 transition-transform" />
               </a>

--- a/components/token-card.tsx
+++ b/components/token-card.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { DashcoinCard } from "@/components/ui/dashcoin-card";
+import Image from "next/image";
 import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from "@/components/ui/tooltip";
 import AnimatedMarketCap from "@/components/animated-marketcap";
 import { canonicalChecklist } from "@/components/founders-edge-checklist";
@@ -98,10 +99,19 @@ export function TokenCard({ token, researchScore }: TokenCardProps) {
           <Link href={`/tokendetail/${tokenSymbol}`} className="group/link flex-1">
             <div className="flex items-center gap-3 mb-2">
               <div className="relative">
-                {/* Token Avatar Placeholder */}
-                <div className="w-10 h-10 bg-gradient-to-br from-teal-500 to-green-600 rounded-xl flex items-center justify-center text-white font-bold text-sm">
-                  {tokenSymbol.substring(0, 2)}
-                </div>
+                {token.logoUrl ? (
+                  <Image
+                    src={token.logoUrl}
+                    alt={`${tokenSymbol} logo`}
+                    width={40}
+                    height={40}
+                    className="w-10 h-10 rounded-xl object-cover"
+                  />
+                ) : (
+                  <div className="w-10 h-10 bg-gradient-to-br from-teal-500 to-green-600 rounded-xl flex items-center justify-center text-white font-bold text-sm">
+                    {tokenSymbol.substring(0, 2)}
+                  </div>
+                )}
                 <div className="absolute -bottom-1 -right-1 w-4 h-4 bg-emerald-500 rounded-full border-2 border-slate-950 flex items-center justify-center">
                   <div className="w-1.5 h-1.5 bg-white rounded-full animate-pulse"></div>
                 </div>

--- a/components/token-search-list.tsx
+++ b/components/token-search-list.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useMemo, useCallback } from "react";
+import Image from "next/image";
 import type { TokenData } from "@/types/dune";
 import {
   fetchTokenResearch,
@@ -69,12 +70,13 @@ export default function TokenSearchList() {
       addresses.forEach(addr => {
         const d = map.get(addr);
         if (d && d.pairs && d.pairs.length > 0) {
-          const p = d.pairs[0];
+          const p = d.pairs[0] as any;
           result[addr] = {
             volume24h: p.volume?.h24 || 0,
             change24h: p.priceChange?.h24 || 0,
             marketCap: p.fdv || 0,
             liquidity: p.liquidity?.usd || 0,
+            logoUrl: p.baseToken?.imageUrl || p.info?.imageUrl || p.baseToken?.logoURI,
           };
         }
       });
@@ -143,6 +145,7 @@ export default function TokenSearchList() {
         ...research,
         ...wallet,
         marketCap: dex.marketCap ?? t.marketCap,
+        logoUrl: dex.logoUrl,
       };
     });
   }, [tokens, researchScores, dexscreenerData, walletInfo]);
@@ -434,12 +437,6 @@ export default function TokenSearchList() {
                   </th>
                   <th className="text-left py-4 px-6 text-slate-300 font-medium">
                     <div className="flex items-center gap-2">
-                      <TrendingUp className="w-4 h-4" />
-                      Liquidity
-                    </div>
-                  </th>
-                  <th className="text-left py-4 px-6 text-slate-300 font-medium">
-                    <div className="flex items-center gap-2">
                       <Star className="w-4 h-4" />
                       Research
                     </div>
@@ -452,9 +449,19 @@ export default function TokenSearchList() {
                   <tr key={idx} className="border-b border-white/5 hover:bg-white/5 transition-colors group">
                     <td className="py-4 px-6">
                       <Link href={`/tokendetail/${token.symbol}`} className="flex items-center gap-3 group-hover:text-teal-400 transition-colors">
-                        <div className="w-8 h-8 bg-gradient-to-br from-teal-500 to-green-600 rounded-lg flex items-center justify-center text-white font-bold text-xs">
-                          {(token.symbol || '').substring(0, 2)}
-                        </div>
+                        {token.logoUrl ? (
+                          <Image
+                            src={token.logoUrl}
+                            alt={`${token.symbol} logo`}
+                            width={32}
+                            height={32}
+                            className="w-8 h-8 rounded-lg object-cover"
+                          />
+                        ) : (
+                          <div className="w-8 h-8 bg-gradient-to-br from-teal-500 to-green-600 rounded-lg flex items-center justify-center text-white font-bold text-xs">
+                            {(token.symbol || '').substring(0, 2)}
+                          </div>
+                        )}
                         <div>
                           <div className="font-bold text-white">{token.symbol}</div>
                           {token.name && (
@@ -476,11 +483,6 @@ export default function TokenSearchList() {
                         {(token.change24h || 0) > 0 ? <TrendingUp className="w-3 h-3" /> : 
                          (token.change24h || 0) < 0 ? <TrendingDown className="w-3 h-3" /> : null}
                         {Math.abs(token.change24h || 0).toFixed(2)}%
-                      </div>
-                    </td>
-                    <td className="py-4 px-6">
-                      <div className="text-white font-medium">
-                        ${formatCompactNumber(token.liquidity || 0)}
                       </div>
                     </td>
                     <td className="py-4 px-6">


### PR DESCRIPTION
## Summary
- show Coming Soon badge on Chrome extension link
- fetch token logo URLs
- display token logos in table and card views
- drop Liquidity column from token table

## Testing
- `npm test`
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68422afda8ec832c8162fe7595d9238a