### PR TITLE
Rename volume card on homepage

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -368,7 +368,7 @@ export default async function Home() {
             />
             <QuickStatsCard
               icon={Activity}
-              title="24h Volume"
+              title="Total Volume"
               value={formattedVolume}
               change="+8.2%"
               changeType="positive"


### PR DESCRIPTION
## Summary
- rename the quick stats card label from `24h Volume` to `Total Volume`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68422c00b264832c91300850e09c812c