### PR TITLE
Fix token card click navigation

### DIFF
--- a/components/token-card.tsx
+++ b/components/token-card.tsx
@@ -26,7 +26,6 @@ import {
   Activity
 } from "lucide-react";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 
 const checklistIcons: Record<string, JSX.Element> = {
   "Team Doxxed": <User className="h-3 w-3" />,
@@ -71,32 +70,22 @@ export interface TokenCardProps {
 }
 
 export function TokenCard({ token, researchScore }: TokenCardProps) {
-  const router = useRouter();
   const tokenAddress = token.token || "";
   const tokenSymbol = token.symbol || "???";
   const change24h = token.change24h || 0;
 
-  const handleCardClick = (e: React.MouseEvent) => {
-    const target = e.target as HTMLElement;
-    if (target.closest('a,button')) {
-      return;
-    }
-    router.push(`/tokendetail/${tokenSymbol}`);
-  };
-
   return (
-    <div className="group relative">
+    <Link href={`/tokendetail/${tokenSymbol}`} className="group relative block">
       {/* Glow Effect */}
       <div className="absolute inset-0 bg-gradient-to-r from-teal-500/10 to-green-500/10 rounded-2xl opacity-0 group-hover:opacity-100 transition-all duration-500 blur-xl"></div>
-      
+
       {/* Main Card */}
-      <DashcoinCard 
-        onClick={handleCardClick} 
+      <DashcoinCard
         className="relative cursor-pointer p-6 flex flex-col gap-5 transition-all duration-300 hover:-translate-y-1 hover:shadow-2xl border-white/10 hover:border-white/20 bg-white/5 backdrop-blur-xl hover:bg-white/[0.08]"
       >
         {/* Header Section */}
         <div className="flex justify-between items-start">
-          <Link href={`/tokendetail/${tokenSymbol}`} className="group/link flex-1">
+          <div className="group/link flex-1">
             <div className="flex items-center gap-3 mb-2">
               <div className="relative">
                 {token.logoUrl ? (
@@ -129,7 +118,7 @@ export function TokenCard({ token, researchScore }: TokenCardProps) {
                 )}
               </div>
             </div>
-          </Link>
+          </div>
 
           {/* Research Score Badge */}
           {researchScore !== null && (
@@ -229,31 +218,28 @@ export function TokenCard({ token, researchScore }: TokenCardProps) {
 
         {/* Action Section */}
         <div className="flex items-center justify-between mt-auto pt-4 border-t border-white/10">
-          <Link 
-            href={`/tokendetail/${tokenSymbol}`} 
-            className="group/detail flex items-center gap-2 px-4 py-2 bg-white/5 hover:bg-white/10 border border-white/10 hover:border-white/20 text-slate-300 hover:text-white rounded-lg transition-all duration-200"
-          >
+          <div className="group/detail flex items-center gap-2 px-4 py-2 bg-white/5 hover:bg-white/10 border border-white/10 hover:border-white/20 text-slate-300 hover:text-white rounded-lg transition-all duration-200">
             <span className="text-sm font-medium">View Details</span>
             <ArrowUpRight className="w-3 h-3 group-hover/detail:translate-x-0.5 group-hover/detail:-translate-y-0.5 transition-transform" />
-          </Link>
+          </div>
 
-          <a
-            href={tokenAddress ? `https://axiom.trade/t/${tokenAddress}/dashc` : '#'}
-            target="_blank"
-            rel="noopener noreferrer"
+          <button
+            type="button"
             className="group/trade relative flex items-center gap-2 px-4 py-2 bg-gradient-to-r from-teal-600 to-teal-600 hover:from-teal-500 hover:to-green-500 text-white rounded-lg transition-all duration-200 transform hover:scale-105 shadow-lg hover:shadow-xl disabled:opacity-50 disabled:cursor-not-allowed"
             onClick={(e) => {
-              if (!tokenAddress) {
-                e.preventDefault();
+              e.stopPropagation();
+              if (tokenAddress) {
+                window.open(`https://axiom.trade/t/${tokenAddress}/dashc`, '_blank');
               }
             }}
+            disabled={!tokenAddress}
           >
             <Zap className="w-4 h-4" />
             <span className="text-sm font-semibold">TRADE</span>
             <ExternalLink className="w-3 h-3 opacity-60 group-hover/trade:opacity-100 transition-opacity" />
-          </a>
+          </button>
         </div>
       </DashcoinCard>
-    </div>
+    </Link>
   );
 }


### PR DESCRIPTION
## Summary
- wrap each `TokenCard` with a `Link` so the whole card navigates
- convert the trade link to a button that opens the trading site

## Testing
- `./setup.sh` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684232e13590832c89c6a9f73d5b6513