### PR TITLE
Remove tagline and export button on Compare page

### DIFF
--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -1028,7 +1028,6 @@ export default function ComparePage() {
                   </div>
                   <div>
                     <h3 className="text-xl font-bold text-white">Dashcoin Research</h3>
-                    <p className="text-sm text-slate-400">Token Comparison Platform</p>
                   </div>
                 </div>
                 <p className="text-slate-400 text-sm leading-relaxed">
@@ -1048,22 +1047,13 @@ export default function ComparePage() {
                     <span>New Comparison</span>
                   </button>
                   {comparisonData.token1 && comparisonData.token2 && (
-                    <>
-                      <button 
-                        onClick={exportCsv}
-                        className="flex items-center gap-2 text-slate-400 hover:text-white transition-colors group"
-                      >
-                        <Download className="w-4 h-4" />
-                        <span>Export Data</span>
-                      </button>
-                      <button 
+                      <button
                         onClick={handleReverseCompare}
                         className="flex items-center gap-2 text-slate-400 hover:text-white transition-colors group"
                       >
                         <ArrowLeftRight className="w-4 h-4" />
                         <span>Reverse Comparison</span>
                       </button>
-                    </>
                   )}
                 </div>
               </div>

--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -1026,9 +1026,7 @@ export default function ComparePage() {
                     <div className="absolute inset-0 bg-gradient-to-r from-teal-500 to-teal-600 rounded-full blur-lg opacity-30 animate-pulse"></div>
                     <DashcoinLogo size={40} />
                   </div>
-                  <div>
-                    <h3 className="text-xl font-bold text-white">Dashcoin Research</h3>
-                  </div>
+
                 </div>
                 <p className="text-slate-400 text-sm leading-relaxed">
                   Advanced analytics and comparative insights for the Believe coin ecosystem.


### PR DESCRIPTION
## Summary
- clean up Compare page footer text
- remove Export Data quick action button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684236b27568832ca9b2e687fd79ced8