### PR TITLE
Refactor token card navigation

### DIFF
--- a/components/token-card.tsx
+++ b/components/token-card.tsx
@@ -76,13 +76,9 @@ export function TokenCard({ token, researchScore }: TokenCardProps) {
   const tokenSymbol = token.symbol || "???";
   const change24h = token.change24h || 0;
 
-  const handleCardClick = (e: React.MouseEvent) => {
-    const target = e.target as HTMLElement;
-    if (target.closest('a,button')) {
-      return;
-    }
-    router.push(`/tokendetail/${tokenSymbol}`);
-  };
+  const navigateToDetails = () => {
+    router.push(`/tokendetail/${tokenSymbol}`)
+  }
 
   return (
     <div className="group relative">
@@ -90,13 +86,17 @@ export function TokenCard({ token, researchScore }: TokenCardProps) {
       <div className="absolute inset-0 bg-gradient-to-r from-teal-500/10 to-green-500/10 rounded-2xl opacity-0 group-hover:opacity-100 transition-all duration-500 blur-xl"></div>
       
       {/* Main Card */}
-      <DashcoinCard 
-        onClick={handleCardClick} 
+      <DashcoinCard
+        onClick={navigateToDetails}
         className="relative cursor-pointer p-6 flex flex-col gap-5 transition-all duration-300 hover:-translate-y-1 hover:shadow-2xl border-white/10 hover:border-white/20 bg-white/5 backdrop-blur-xl hover:bg-white/[0.08]"
       >
         {/* Header Section */}
         <div className="flex justify-between items-start">
-          <Link href={`/tokendetail/${tokenSymbol}`} className="group/link flex-1">
+          <Link
+            href={`/tokendetail/${tokenSymbol}`}
+            className="group/link flex-1"
+            onClick={e => e.stopPropagation()}
+          >
             <div className="flex items-center gap-3 mb-2">
               <div className="relative">
                 {token.logoUrl ? (
@@ -229,9 +229,10 @@ export function TokenCard({ token, researchScore }: TokenCardProps) {
 
         {/* Action Section */}
         <div className="flex items-center justify-between mt-auto pt-4 border-t border-white/10">
-          <Link 
-            href={`/tokendetail/${tokenSymbol}`} 
+          <Link
+            href={`/tokendetail/${tokenSymbol}`}
             className="group/detail flex items-center gap-2 px-4 py-2 bg-white/5 hover:bg-white/10 border border-white/10 hover:border-white/20 text-slate-300 hover:text-white rounded-lg transition-all duration-200"
+            onClick={e => e.stopPropagation()}
           >
             <span className="text-sm font-medium">View Details</span>
             <ArrowUpRight className="w-3 h-3 group-hover/detail:translate-x-0.5 group-hover/detail:-translate-y-0.5 transition-transform" />
@@ -242,9 +243,10 @@ export function TokenCard({ token, researchScore }: TokenCardProps) {
             target="_blank"
             rel="noopener noreferrer"
             className="group/trade relative flex items-center gap-2 px-4 py-2 bg-gradient-to-r from-teal-600 to-teal-600 hover:from-teal-500 hover:to-green-500 text-white rounded-lg transition-all duration-200 transform hover:scale-105 shadow-lg hover:shadow-xl disabled:opacity-50 disabled:cursor-not-allowed"
-            onClick={(e) => {
+            onClick={e => {
+              e.stopPropagation()
               if (!tokenAddress) {
-                e.preventDefault();
+                e.preventDefault()
               }
             }}
           >


### PR DESCRIPTION
## Summary
- update navigation handler for token cards
- stop card click from firing on inner links

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684257520430832ca61f33230c96b759