### PR TITLE
Update card click handling

### DIFF
--- a/components/token-card.tsx
+++ b/components/token-card.tsx
@@ -128,13 +128,27 @@ export function TokenCard({ token, researchScore }: TokenCardProps) {
               
               <div className="flex-1 min-w-0">
                 <div className="flex items-center gap-2">
-                  <h3 className="text-lg font-bold text-white group-hover/link:text-teal-400 transition-colors truncate">
+                  <h3
+                    className="text-lg font-bold text-white group-hover/link:text-teal-400 transition-colors truncate"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      router.push(`/tokendetail/${tokenSymbol}`);
+                    }}
+                  >
                     {tokenSymbol}
                   </h3>
                   <ArrowUpRight className="w-4 h-4 text-slate-400 opacity-0 group-hover/link:opacity-100 transition-all duration-200 transform group-hover/link:translate-x-0.5 group-hover/link:-translate-y-0.5" />
                 </div>
                 {token.name && (
-                  <p className="text-sm text-slate-400 truncate">{token.name}</p>
+                  <p
+                    className="text-sm text-slate-400 truncate"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      router.push(`/tokendetail/${tokenSymbol}`);
+                    }}
+                  >
+                    {token.name}
+                  </p>
                 )}
               </div>
             </div>

--- a/components/token-card.tsx
+++ b/components/token-card.tsx
@@ -25,7 +25,6 @@ import {
   Shield,
   Activity
 } from "lucide-react";
-import Link from "next/link";
 import { useRouter } from "next/navigation";
 
 const checklistIcons: Record<string, JSX.Element> = {
@@ -76,27 +75,37 @@ export function TokenCard({ token, researchScore }: TokenCardProps) {
   const tokenSymbol = token.symbol || "???";
   const change24h = token.change24h || 0;
 
-  const handleCardClick = (e: React.MouseEvent) => {
-    const target = e.target as HTMLElement;
-    if (target.closest('a,button')) {
+
+  const handleWrapperClick = (e: React.MouseEvent<HTMLAnchorElement>) => {
+    if (
+      e.button !== 0 ||
+      e.metaKey ||
+      e.ctrlKey ||
+      e.shiftKey ||
+      e.altKey
+    ) {
       return;
     }
+    e.preventDefault();
     router.push(`/tokendetail/${tokenSymbol}`);
   };
 
   return (
-    <div className="group relative">
+    <a
+      href={`/tokendetail/${tokenSymbol}`}
+      onClick={handleWrapperClick}
+      className="group relative block"
+    >
       {/* Glow Effect */}
       <div className="absolute inset-0 bg-gradient-to-r from-teal-500/10 to-green-500/10 rounded-2xl opacity-0 group-hover:opacity-100 transition-all duration-500 blur-xl"></div>
-      
+
       {/* Main Card */}
-      <DashcoinCard 
-        onClick={handleCardClick} 
+      <DashcoinCard
         className="relative cursor-pointer p-6 flex flex-col gap-5 transition-all duration-300 hover:-translate-y-1 hover:shadow-2xl border-white/10 hover:border-white/20 bg-white/5 backdrop-blur-xl hover:bg-white/[0.08]"
       >
         {/* Header Section */}
         <div className="flex justify-between items-start">
-          <Link href={`/tokendetail/${tokenSymbol}`} className="group/link flex-1">
+          <div className="group/link flex-1">
             <div className="flex items-center gap-3 mb-2">
               <div className="relative">
                 {token.logoUrl ? (
@@ -129,7 +138,7 @@ export function TokenCard({ token, researchScore }: TokenCardProps) {
                 )}
               </div>
             </div>
-          </Link>
+          </div>
 
           {/* Research Score Badge */}
           {researchScore !== null && (
@@ -229,13 +238,16 @@ export function TokenCard({ token, researchScore }: TokenCardProps) {
 
         {/* Action Section */}
         <div className="flex items-center justify-between mt-auto pt-4 border-t border-white/10">
-          <Link 
-            href={`/tokendetail/${tokenSymbol}`} 
+          <button
             className="group/detail flex items-center gap-2 px-4 py-2 bg-white/5 hover:bg-white/10 border border-white/10 hover:border-white/20 text-slate-300 hover:text-white rounded-lg transition-all duration-200"
+            onClick={(e) => {
+              e.stopPropagation();
+              router.push(`/tokendetail/${tokenSymbol}`);
+            }}
           >
             <span className="text-sm font-medium">View Details</span>
             <ArrowUpRight className="w-3 h-3 group-hover/detail:translate-x-0.5 group-hover/detail:-translate-y-0.5 transition-transform" />
-          </Link>
+          </button>
 
           <a
             href={tokenAddress ? `https://axiom.trade/t/${tokenAddress}/dashc` : '#'}
@@ -243,6 +255,7 @@ export function TokenCard({ token, researchScore }: TokenCardProps) {
             rel="noopener noreferrer"
             className="group/trade relative flex items-center gap-2 px-4 py-2 bg-gradient-to-r from-teal-600 to-teal-600 hover:from-teal-500 hover:to-green-500 text-white rounded-lg transition-all duration-200 transform hover:scale-105 shadow-lg hover:shadow-xl disabled:opacity-50 disabled:cursor-not-allowed"
             onClick={(e) => {
+              e.stopPropagation();
               if (!tokenAddress) {
                 e.preventDefault();
               }
@@ -254,6 +267,6 @@ export function TokenCard({ token, researchScore }: TokenCardProps) {
           </a>
         </div>
       </DashcoinCard>
-    </div>
+    </a>
   );
 }


### PR DESCRIPTION
## Summary
- make the whole `TokenCard` clickable using a single anchor wrapper
- remove nested `Link` components and old click handler
- stop propagation for the `TRADE` and "View Details" buttons

## Testing
- `npm test`
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6842575fcb60832c91003bf49c24bbe7