### PR TITLE
Improve research trait display

### DIFF
--- a/components/founder-metadata-grid.tsx
+++ b/components/founder-metadata-grid.tsx
@@ -32,7 +32,7 @@ export function FounderMetadataGrid({ token1, token2 }: Props) {
 
   const rows = [
     { label: "Research Score", val1: token1.score, val2: token2.score, score: true },
-    ...canonicalChecklist.map(label => ({ label, val1: token1[label], val2: token2[label], score: false })),
+    ...canonicalChecklist.map(trait => ({ label: trait.label, val1: token1[trait.label], val2: token2[trait.label], score: false })),
   ];
 
   return (

--- a/components/founder-metadata-grid.tsx
+++ b/components/founder-metadata-grid.tsx
@@ -53,7 +53,7 @@ export function FounderMetadataGrid({ token1, token2 }: Props) {
         const col2 = score ? scoreColor(val2 as number | null) : traitColor(val2, label);
         return (
           <div key={label} className="flex flex-col md:grid md:grid-cols-3 py-2 gap-2 group">
-            <TooltipProvider delayDuration={0}>
+            <TooltipProvider delayDuration={100}>
               <Tooltip>
                 <TooltipTrigger asChild>
                   <div className="px-2 font-medium cursor-help text-gray-50">{label}</div>

--- a/components/founders-edge-checklist.tsx
+++ b/components/founders-edge-checklist.tsx
@@ -3,15 +3,56 @@ import { CheckCircle, XCircle, MinusCircle } from "lucide-react";
 import React from "react";
 import { gradeMaps, valueToScore, computeFounderScore } from "@/lib/score";
 
-export const canonicalChecklist = [
-  "Team Doxxed",
-  "Twitter Activity Level",
-  "Time Commitment",
-  "Prior Founder Experience",
-  "Product Maturity",
-  "Funding Status",
-  "Token-Product Integration Depth",
-  "Social Reach & Engagement Index",
+export interface TraitInfo {
+  label: string;
+  category: string;
+  description: string;
+}
+
+export const canonicalChecklist: TraitInfo[] = [
+  {
+    label: "Team Doxxed",
+    category: "Team",
+    description:
+      "This team has disclosed legal names. This boosts trust in volatile markets.",
+  },
+  {
+    label: "Twitter Activity Level",
+    category: "Community",
+    description: "How frequently the team engages on Twitter and shares updates.",
+  },
+  {
+    label: "Time Commitment",
+    category: "Team",
+    description:
+      "Indicates if the founders are working full time or part time on the project.",
+  },
+  {
+    label: "Prior Founder Experience",
+    category: "Team",
+    description: "Number of past startups founded by the team members.",
+  },
+  {
+    label: "Product Maturity",
+    category: "Product",
+    description:
+      "Stage of the product: prototype, MVP, or revenue generating.",
+  },
+  {
+    label: "Funding Status",
+    category: "Funding",
+    description: "Whether the project is venture backed, angel funded or bootstrapped.",
+  },
+  {
+    label: "Token-Product Integration Depth",
+    category: "Product",
+    description: "How integrated the token is within the live product.",
+  },
+  {
+    label: "Social Reach & Engagement Index",
+    category: "Community",
+    description: "Overall social following and engagement of the project.",
+  },
 ];
 
 function getIcon(value: number) {
@@ -49,7 +90,7 @@ export function FoundersEdgeChecklist({ data, showLegend = false }: ChecklistPro
       </div>
       <p className="text-base opacity-80 mb-6 text-center">Signal-based checklist of founder credibility and product traction.</p>
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-        {canonicalChecklist.map((label) => {
+        {canonicalChecklist.map(({ label }) => {
           const raw = data[label];
           const val = valueToScore(raw, (gradeMaps as any)[label]);
           return (

--- a/components/token-card.tsx
+++ b/components/token-card.tsx
@@ -6,6 +6,7 @@ import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from "@/comp
 import AnimatedMarketCap from "@/components/animated-marketcap";
 import { canonicalChecklist } from "@/components/founders-edge-checklist";
 import { valueToScore } from "@/lib/score";
+import { useState } from "react";
 import {
   User, 
   Twitter, 
@@ -75,6 +76,7 @@ export function TokenCard({ token, researchScore }: TokenCardProps) {
   const tokenAddress = token.token || "";
   const tokenSymbol = token.symbol || "???";
   const change24h = token.change24h || 0;
+  const [showAllTraits, setShowAllTraits] = useState(false);
 
   const handleCardClick = (e: React.MouseEvent) => {
     const target = e.target as HTMLElement;
@@ -200,8 +202,10 @@ export function TokenCard({ token, researchScore }: TokenCardProps) {
           </div>
           
           <div className="flex flex-wrap gap-1.5">
-            {canonicalChecklist.slice(0, 6).map(label => {
+            {(showAllTraits ? canonicalChecklist : canonicalChecklist.slice(0, 4)).map(({ label, description }) => {
               const value = (token as any)[label];
+              const score = valueToScore(value);
+              const rating = score === 2 ? "✓" : score === 1 ? "⚠️" : "?";
               return (
                 <TooltipProvider delayDuration={0} key={label}>
                   <Tooltip>
@@ -211,18 +215,23 @@ export function TokenCard({ token, researchScore }: TokenCardProps) {
                         <span>{value || '-'}</span>
                       </div>
                     </TooltipTrigger>
-                    <TooltipContent side="top" className="bg-slate-800 border-slate-700">
-                      <p className="text-xs">{label}</p>
+                    <TooltipContent side="top" className="bg-slate-800 border-slate-700 max-w-xs text-left">
+                      <p className="text-xs font-semibold mb-1">{label} {rating}</p>
+                      <p className="text-xs opacity-80">{description}</p>
                     </TooltipContent>
                   </Tooltip>
                 </TooltipProvider>
               );
             })}
-            
-            {canonicalChecklist.length > 6 && (
-              <div className="flex items-center px-2 py-1 bg-slate-600/20 border border-slate-600/30 rounded-lg text-xs text-slate-400">
-                +{canonicalChecklist.length - 6} more
-              </div>
+
+            {!showAllTraits && canonicalChecklist.length > 4 && (
+              <button
+                type="button"
+                onClick={() => setShowAllTraits(true)}
+                className="flex items-center px-2 py-1 bg-slate-600/20 border border-slate-600/30 rounded-lg text-xs text-slate-400"
+              >
+                +{canonicalChecklist.length - 4} more
+              </button>
             )}
           </div>
         </div>

--- a/components/token-card.tsx
+++ b/components/token-card.tsx
@@ -24,7 +24,8 @@ import {
   Zap,
   Star,
   Shield,
-  Activity
+  Activity,
+  Info
 } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
@@ -207,16 +208,20 @@ export function TokenCard({ token, researchScore }: TokenCardProps) {
               const score = valueToScore(value);
               const rating = score === 2 ? "✓" : score === 1 ? "⚠️" : "?";
               return (
-                <TooltipProvider delayDuration={0} key={label}>
+                <TooltipProvider delayDuration={100} key={label}>
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <div className={`flex items-center gap-1 px-2 py-1 rounded-lg border text-xs font-medium transition-all duration-200 hover:scale-105 ${badgeColor(value)}`}>
                         {checklistIcons[label]}
                         <span>{value || '-'}</span>
+                        <Info className="w-3 h-3 text-slate-300" />
                       </div>
                     </TooltipTrigger>
-                    <TooltipContent side="top" className="bg-slate-800 border-slate-700 max-w-xs text-left">
-                      <p className="text-xs font-semibold mb-1">{label} {rating}</p>
+                    <TooltipContent side="top" className="max-w-xs text-left">
+                      <p className="text-xs font-semibold mb-1 flex items-center gap-1">
+                        {checklistIcons[label]}
+                        {label} {rating}
+                      </p>
                       <p className="text-xs opacity-80">{description}</p>
                     </TooltipContent>
                   </Tooltip>

--- a/components/token-table.tsx
+++ b/components/token-table.tsx
@@ -461,7 +461,7 @@ export default function TokenTable({ data }: { data: PaginatedTokenResponse | To
                 </th>
                 {canonicalChecklist.map(({ label, description }) => (
                   <th key={label} className="relative text-left py-3 px-4 text-dashYellow">
-                    <TooltipProvider delayDuration={0}>
+                    <TooltipProvider delayDuration={100}>
                       <Tooltip>
                         <TooltipTrigger asChild>
                           <div className="flex items-center gap-1 cursor-pointer">

--- a/components/token-table.tsx
+++ b/components/token-table.tsx
@@ -79,7 +79,8 @@ export default function TokenTable({ data }: { data: PaginatedTokenResponse | To
   const [checklistFilters, setChecklistFilters] = useState<Record<string, string[]>>(
     () => {
       const initial: Record<string, string[]> = {}
-      canonicalChecklist.forEach(label => {
+      canonicalChecklist.forEach(trait => {
+        const label = trait.label
         const param = searchParams.get(label)
         initial[label] = param ? param.split('|') : []
       })
@@ -152,7 +153,8 @@ export default function TokenTable({ data }: { data: PaginatedTokenResponse | To
       const research = researchScores.find(
         item => item.symbol.toUpperCase() === (token.symbol || '').toUpperCase()
       )
-      return canonicalChecklist.every(label => {
+      return canonicalChecklist.every(trait => {
+        const label = trait.label
         const selected = checklistFilters[label]
         if (!selected || selected.length === 0) return true
         let raw = research ? research[label] : ''
@@ -166,7 +168,8 @@ export default function TokenTable({ data }: { data: PaginatedTokenResponse | To
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search)
-    canonicalChecklist.forEach(label => {
+    canonicalChecklist.forEach(trait => {
+      const label = trait.label
       const values = checklistFilters[label]
       if (values && values.length > 0) {
         params.set(label, values.join('|'))
@@ -456,7 +459,7 @@ export default function TokenTable({ data }: { data: PaginatedTokenResponse | To
                     {renderSortIndicator("researchScore")}
                   </div>
                 </th>
-                {canonicalChecklist.map(label => (
+                {canonicalChecklist.map(({ label, description }) => (
                   <th key={label} className="relative text-left py-3 px-4 text-dashYellow">
                     <TooltipProvider delayDuration={0}>
                       <Tooltip>
@@ -465,7 +468,10 @@ export default function TokenTable({ data }: { data: PaginatedTokenResponse | To
                             {checklistIcons[label]}
                           </div>
                         </TooltipTrigger>
-                        <TooltipContent>{label}</TooltipContent>
+                        <TooltipContent className="max-w-xs text-left">
+                          <p className="text-xs font-semibold mb-1">{label}</p>
+                          <p className="text-xs opacity-80">{description}</p>
+                        </TooltipContent>
                       </Tooltip>
                     </TooltipProvider>
                     <Filter
@@ -586,7 +592,8 @@ export default function TokenTable({ data }: { data: PaginatedTokenResponse | To
                           <span className="text-dashYellow-light opacity-50">-</span>
                         )}
                       </td>
-                      {canonicalChecklist.map(label => {
+                      {canonicalChecklist.map(trait => {
+                        const label = trait.label
                         const raw = (token as any)[label]
                         const display = raw !== undefined && raw !== '' ? raw : '-'
                         return (

--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -14,12 +14,12 @@ const TooltipTrigger = TooltipPrimitive.Trigger
 const TooltipContent = React.forwardRef<
   React.ElementRef<typeof TooltipPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
->(({ className, sideOffset = 4, ...props }, ref) => (
+>(({ className, sideOffset = 8, ...props }, ref) => (
   <TooltipPrimitive.Content
     ref={ref}
     sideOffset={sideOffset}
     className={cn(
-      "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      "z-50 overflow-hidden rounded-xl border border-slate-700 bg-slate-800/90 backdrop-blur-md px-4 py-2 text-sm text-slate-100 shadow-lg transition-opacity duration-200 animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
       className
     )}
     {...props}


### PR DESCRIPTION
## Summary
- restructure canonical checklist with categories and descriptions
- show improved trait tooltips in TokenCard and TokenTable
- allow expanding full trait list
- adjust FounderMetadataGrid usage

## Testing
- `npm test`
- `npm run lint` *(fails: `next` not found)*
- `npx tsc --noEmit` *(fails: missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_68426e0b8ec0832c954b34dc8fbf7145