### PR TITLE
Fix fluctuating marketcap display

### DIFF
--- a/components/animated-marketcap.tsx
+++ b/components/animated-marketcap.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState, useEffect, useMemo } from "react";
+import { useMemo } from "react";
 
 interface AnimatedMarketCapProps {
   value: number;
@@ -7,35 +7,7 @@ interface AnimatedMarketCapProps {
 }
 
 export default function AnimatedMarketCap({ value, decimals = 0 }: AnimatedMarketCapProps) {
-  const [base, setBase] = useState(Math.floor(value / 10000) * 10000);
-  const [digits, setDigits] = useState(value % 10000);
-  const [flash, setFlash] = useState(false);
-
-  useEffect(() => {
-    setBase(Math.floor(value / 10000) * 10000);
-    setDigits(value % 10000);
-  }, [value]);
-
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setDigits(prev => {
-        let next = prev + Math.floor(Math.random() * 2000) - 1000; // +/-1000
-        if (next < 0) next += 10000;
-        if (next >= 10000) next -= 10000;
-        return next;
-      });
-      setFlash(true);
-    }, 800);
-    return () => clearInterval(interval);
-  }, [base]);
-
-  useEffect(() => {
-    if (!flash) return;
-    const t = setTimeout(() => setFlash(false), 150);
-    return () => clearTimeout(t);
-  }, [flash]);
-
-  const displayValue = base + digits;
+  const displayValue = value;
   const formatter = useMemo(() =>
     new Intl.NumberFormat("en-US", {
       style: "currency",
@@ -44,5 +16,5 @@ export default function AnimatedMarketCap({ value, decimals = 0 }: AnimatedMarke
       maximumFractionDigits: decimals,
     }), [decimals]);
 
-  return <span className={flash ? "price-flash" : undefined}>{formatter.format(displayValue)}</span>;
+  return <span>{formatter.format(displayValue)}</span>;
 }

--- a/components/dashc-stats-bar.tsx
+++ b/components/dashc-stats-bar.tsx
@@ -1,5 +1,4 @@
 import { formatCurrency } from "@/lib/utils";
-import AnimatedMarketCap from "@/components/animated-marketcap";
 import { CopyAddress } from "@/components/copy-address";
 import { TrendingUp, ExternalLink, Zap } from "lucide-react";
 

--- a/components/token-card.tsx
+++ b/components/token-card.tsx
@@ -3,7 +3,6 @@
 import { DashcoinCard } from "@/components/ui/dashcoin-card";
 import Image from "next/image";
 import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from "@/components/ui/tooltip";
-import AnimatedMarketCap from "@/components/animated-marketcap";
 import { canonicalChecklist } from "@/components/founders-edge-checklist";
 import { valueToScore } from "@/lib/score";
 import { useState } from "react";

--- a/components/token-search-list.tsx
+++ b/components/token-search-list.tsx
@@ -31,7 +31,6 @@ import {
   X
 } from "lucide-react";
 import { formatCurrency0 } from "@/lib/utils";
-import AnimatedMarketCap from "@/components/animated-marketcap";
 import Link from "next/link";
 
 interface ResearchScoreData {


### PR DESCRIPTION
## Summary
- remove animated marketcap effect and show a static value
- clean up unused imports

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68428d3332e0832c817d5fc5bc55e5c5