### PR TITLE
Fix chart titles visibility

### DIFF
--- a/components/market-cap-chart.tsx
+++ b/components/market-cap-chart.tsx
@@ -149,7 +149,7 @@ export function MarketCapChart({ data }: MarketCapChartProps) {
   return (
     <DashcoinCard>
       <DashcoinCardHeader>
-        <DashcoinCardTitle>Market Cap & Holders Over Time</DashcoinCardTitle>
+        <DashcoinCardTitle className="text-white">Market Cap & Holders Over Time</DashcoinCardTitle>
       </DashcoinCardHeader>
       <DashcoinCardContent>
         <div className="h-64 bg-neutral-900 rounded-lg">

--- a/components/market-cap-pie.tsx
+++ b/components/market-cap-pie.tsx
@@ -123,7 +123,7 @@ export function MarketCapPie({ data }: MarketCapPieProps) {
   return (
     <DashcoinCard>
       <DashcoinCardHeader>
-        <DashcoinCardTitle>Market Cap Distribution</DashcoinCardTitle>
+        <DashcoinCardTitle className="text-white">Market Cap Distribution</DashcoinCardTitle>
       </DashcoinCardHeader>
       <DashcoinCardContent>
         {hasData ? (


### PR DESCRIPTION
## Summary
- tweak market cap chart titles to use white text so they stand out

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68428e29d8b0832cb314db7b98a67adf