### PR TITLE
Default overview page to table view

### DIFF
--- a/components/token-search-list.tsx
+++ b/components/token-search-list.tsx
@@ -52,7 +52,7 @@ export default function TokenSearchList() {
   const [researchScores, setResearchScores] = useState<ResearchScoreData[]>([]);
   const [dexscreenerData, setDexscreenerData] = useState<Record<string, any>>({});
   const [walletInfo, setWalletInfo] = useState<Record<string, { walletLink: string; twitter: string }>>({});
-  const [viewMode, setViewMode] = useState<'card' | 'table'>('card');
+  const [viewMode, setViewMode] = useState<'card' | 'table'>('table');
   const [searchTerm, setSearchTerm] = useState("");
   const [pageSize, setPageSize] = useState(12);
   const [currentPage, setCurrentPage] = useState(1);


### PR DESCRIPTION
## Summary
- default TokenSearchList viewMode to `table` so the overview page loads in table view

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684320746720832cb9a84dd3d89c0c26