### PR TITLE
Fix repeated data fetch on token pages

### DIFF
--- a/app/token/[symbol]/page.tsx
+++ b/app/token/[symbol]/page.tsx
@@ -21,7 +21,7 @@ import { formatCurrency } from "@/lib/utils";
 import { ArrowLeft, ExternalLink } from "lucide-react";
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { CopyAddress } from "@/components/copy-address";
 
 export default function TokenPage({ params }: { params: { symbol: string } }) {
@@ -61,7 +61,11 @@ export default function TokenPage({ params }: { params: { symbol: string } }) {
       })
     : "N/A";
 
+  const hasLoaded = useRef(false)
+
   useEffect(() => {
+    if (hasLoaded.current) return
+    hasLoaded.current = true
     async function loadData() {
       try {
         const duneTokenData = await fetchTokenDetails(symbol);

--- a/app/tokendetail/[symbol]/page.tsx
+++ b/app/tokendetail/[symbol]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { 
   Loader2, 
@@ -227,7 +227,11 @@ export default function TokenResearchPage({
     getResearchData();
   }, [symbol]);
 
+  const hasLoaded = useRef(false)
+
   useEffect(() => {
+    if (hasLoaded.current) return
+    hasLoaded.current = true
     async function loadData() {
       try {
         const duneTokenData = await fetchTokenDetails(symbol);


### PR DESCRIPTION
## Summary
- prevent multiple fetches on `token` and `tokendetail` pages by using a ref

## Testing
- `./setup.sh` *(fails: 403 Forbidden - GET https://registry.npmjs.org/date-fns)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68433a3c6624832c8f28beb0408410bd