### PR TITLE
Fix default market cap sorting

### DIFF
--- a/components/token-card-list.tsx
+++ b/components/token-card-list.tsx
@@ -62,11 +62,13 @@ export default function TokenCardList({ data }: { data: PaginatedTokenResponse |
   const getResearch = (symbol: string): ResearchScoreData | undefined =>
     researchScores.find(r => r.symbol.toUpperCase() === symbol.toUpperCase())
 
-  const tokensWithData = tokens.map(t => {
-    const dex = dexscreenerData[t.token] || {}
-    const research = getResearch(t.symbol || "") || {}
-    return { ...t, ...dex, ...research, marketCap: dex.marketCap ?? t.marketCap }
-  })
+  const tokensWithData = [...tokens]
+    .map(t => {
+      const dex = dexscreenerData[t.token] || {}
+      const research = getResearch(t.symbol || "") || {}
+      return { ...t, ...dex, ...research, marketCap: dex.marketCap ?? t.marketCap }
+    })
+    .sort((a, b) => (b.marketCap || 0) - (a.marketCap || 0))
 
   if (isLoading && tokensWithData.length === 0) {
     return (

--- a/components/token-search-list.tsx
+++ b/components/token-search-list.tsx
@@ -183,7 +183,7 @@ export default function TokenSearchList() {
 
     // sorting
     if (sortOption === "mc-desc") {
-      // Tokens are already returned sorted by market cap from the API.
+      result = [...result].sort((a, b) => (b.marketCap || 0) - (a.marketCap || 0));
     } else if (sortOption === "mc-asc") {
       result = [...result].sort((a, b) => (a.marketCap || 0) - (b.marketCap || 0));
     } else if (sortOption === "rs-desc") {

--- a/components/token-table.tsx
+++ b/components/token-table.tsx
@@ -250,18 +250,25 @@ export default function TokenTable({ data }: { data: PaginatedTokenResponse | To
     return scoreData?.score !== undefined ? scoreData.score : null;
   }
 
-  const tokensWithDexData = filteredTokens.map(token => {
-    const tokenAddress = getTokenProperty(token, "token", "");
-    const dexData = tokenAddress && dexscreenerData[tokenAddress] ? dexscreenerData[tokenAddress] : {};
-    const research = researchScores.find(item => item.symbol.toUpperCase() === (token.symbol || '').toUpperCase()) || {};
+  const tokensWithDexData = [...filteredTokens]
+    .map(token => {
+      const tokenAddress = getTokenProperty(token, "token", "");
+      const dexData = tokenAddress && dexscreenerData[tokenAddress] ? dexscreenerData[tokenAddress] : {};
+      const research = researchScores.find(item => item.symbol.toUpperCase() === (token.symbol || '').toUpperCase()) || {};
 
-    return {
-      ...token,
-      ...dexData,
-      ...research,
-      marketCap: dexData.marketCap !== undefined ? dexData.marketCap : token.marketCap,
-    };
-  });
+      return {
+        ...token,
+        ...dexData,
+        ...research,
+        marketCap: dexData.marketCap !== undefined ? dexData.marketCap : token.marketCap,
+      };
+    })
+    .sort((a, b) => {
+      if (sortField !== 'marketCap') return 0;
+      return sortDirection === 'asc'
+        ? (a.marketCap || 0) - (b.marketCap || 0)
+        : (b.marketCap || 0) - (a.marketCap || 0);
+    });
 
   useEffect(() => {
     if (refreshCountdown <= 0) {


### PR DESCRIPTION
## Summary
- sort tokens by marketcap after dex data loads in table and card views
- always sort by marketcap in search list when `mc-desc` is selected

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68435aaf5060832c98ebda141eb4626e