### PR TITLE
Refactor NavBar layout

### DIFF
--- a/app/admin/login/page.tsx
+++ b/app/admin/login/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { Navbar } from '@/components/navbar';
 
 export default function LoginPage() {
   const [email, setEmail] = useState('');
@@ -41,7 +42,8 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-dashGreen-darkest">
+    <div className="min-h-screen flex flex-col items-center justify-center bg-dashGreen-darkest">
+      <Navbar />
       <div className="w-full max-w-md">
         <div className="bg-dashGreen-dark shadow-lg rounded-lg px-8 pt-6 pb-8 mb-4 border border-dashYellow/20">
           <h1 className="text-2xl font-bold text-dashYellow mb-6 text-center">Admin Login</h1>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,6 +21,7 @@ import { formatCurrency, formatCurrency0 } from "@/lib/utils";
 import EnvSetup from "./env-setup";
 import { Suspense } from "react";
 import { Navbar } from "@/components/navbar";
+import { DashcStatsBar } from "@/components/dashc-stats-bar";
 import { 
   Twitter, 
   TrendingUp, 
@@ -304,13 +305,7 @@ export default async function Home() {
 
       {/* Navigation */}
       <div className="relative z-50">
-        <Navbar
-          dashcStats={{
-            tradeLink: dashcoinTradeLink,
-            marketCap: dashcMarketCap,
-            contractAddress: dashcoinCA,
-          }}
-        />
+        <Navbar />
       </div>
 
       <main className="relative z-10 container mx-auto px-4 py-8 max-w-7xl mt-16 mt-16">
@@ -390,6 +385,14 @@ export default async function Home() {
               value={marketStats?.coinLaunches || "N/A"}
               change="+3"
               changeType="positive"
+            />
+          </div>
+
+          <div className="mt-8 flex justify-center">
+            <DashcStatsBar
+              tradeLink={dashcoinTradeLink}
+              marketCap={dashcMarketCap}
+              contractAddress={dashcoinCA}
             />
           </div>
         </section>

--- a/app/token/[symbol]/page.tsx
+++ b/app/token/[symbol]/page.tsx
@@ -2,6 +2,7 @@
 
 import { DashcoinButton } from "@/components/ui/dashcoin-button";
 import { DashcoinLogo } from "@/components/dashcoin-logo";
+import { Navbar } from "@/components/navbar";
 import {
   DashcoinCard,
   DashcoinCardHeader,
@@ -156,13 +157,7 @@ export default function TokenPage({ params }: { params: { symbol: string } }) {
 
   return (
     <div className="min-h-screen">
-      <header className="container mx-auto py-6 px-4">
-        <div className="flex justify-between items-center">
-          <Link href="/">
-            <DashcoinLogo size={48} />
-          </Link>
-        </div>
-      </header>
+      <Navbar />
 
       <main className="container mx-auto px-4 py-6 space-y-8">
         <Link

--- a/app/tokendetail/[symbol]/page.tsx
+++ b/app/tokendetail/[symbol]/page.tsx
@@ -28,6 +28,7 @@ import {
 } from "lucide-react";
 import { DashcoinButton } from "@/components/ui/dashcoin-button";
 import { DashcoinLogo } from "@/components/dashcoin-logo";
+import { Navbar } from "@/components/navbar";
 import {
   DashcoinCard,
   DashcoinCardHeader,
@@ -315,23 +316,7 @@ export default function TokenResearchPage({
       </div>
 
       {/* Navigation */}
-      <header className="relative z-50 border-b border-white/10 bg-white/5 backdrop-blur-xl">
-        <div className="container mx-auto py-4 px-4 max-w-7xl">
-          <div className="flex justify-between items-center">
-            <Link href="/" className="flex items-center gap-3 group">
-              <div className="relative">
-                <div className="absolute inset-0 rounded-full blur-lg opacity-30 group-hover:opacity-50 transition-opacity"></div>
-                <DashcoinLogo size={240} />
-              </div>
-            </Link>
-            
-            <div className="flex items-center gap-2 text-xs text-slate-400">
-              <div className="w-2 h-2 bg-emerald-400 rounded-full animate-pulse"></div>
-              <span>Live Data</span>
-            </div>
-          </div>
-        </div>
-      </header>
+      <Navbar />
 
       <main className="relative z-10 container mx-auto px-4 py-8 max-w-7xl mt-16">
         {/* Back Navigation */}

--- a/components/dashcoin-logo.tsx
+++ b/components/dashcoin-logo.tsx
@@ -19,22 +19,14 @@ export function DashcoinLogo({ className = "", size = 240 }: DashcoinLogoProps) 
     )
   }
 
-  // For smaller sizes (like in the navbar) render the icon with text so the
-  // text color can be easily controlled.
+  // For smaller sizes display the compact logo image
   return (
-    <div className={`flex items-center gap-2 ${className}`}>
-      <Image
-        src="/images/dashcoin.png"
-        alt="Dashcoin logo"
-        width={size}
-        height={size}
-      />
-      <span
-        className="font-bold text-white whitespace-nowrap"
-        style={{ fontSize: `${size * 0.6}px` }}
-      >
-        Dashcoin Research
-      </span>
-    </div>
+    <Image
+      src="/images/dashcoin-logo.png"
+      alt="Dashcoin Research Logo"
+      width={size}
+      height={size}
+      className={className}
+    />
   )
 }

--- a/components/dashcoin-logo.tsx
+++ b/components/dashcoin-logo.tsx
@@ -19,14 +19,22 @@ export function DashcoinLogo({ className = "", size = 240 }: DashcoinLogoProps) 
     )
   }
 
-  // For smaller sizes display the compact logo image
+  // For smaller sizes (like in the navbar) render the icon with text so the
+  // text color can be easily controlled.
   return (
-    <Image
-      src="/images/dashcoin-logo.png"
-      alt="Dashcoin Research Logo"
-      width={size}
-      height={size}
-      className={className}
-    />
+    <div className={`flex items-center gap-2 ${className}`}>
+      <Image
+        src="/images/dashcoin.png"
+        alt="Dashcoin logo"
+        width={size}
+        height={size}
+      />
+      <span
+        className="font-bold text-white whitespace-nowrap"
+        style={{ fontSize: `${size * 0.6}px` }}
+      >
+        Dashcoin Research
+      </span>
+    </div>
   )
 }

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -54,7 +54,7 @@ export function Navbar({ dashcStats }: NavbarProps) {
             : 'bg-slate-950'
         }`}
       >
-        <div className="max-w-9xl mx-auto px-4">
+        <div className="max-w-none mx-auto px-6">
           <div className="flex items-center justify-between h-16">
             {/* Logo */}
             <div className="flex items-center">
@@ -64,7 +64,7 @@ export function Navbar({ dashcStats }: NavbarProps) {
 
             {/* Compact Stats Bar - Center */}
             {dashcStats && (
-              <div className="hidden md:block flex-1 max-w-md mx-8">
+              <div className="hidden md:block flex-1 max-w-lg mx-8">
                 <DashcStatsBar {...dashcStats} />
               </div>
             )}
@@ -114,7 +114,7 @@ export function Navbar({ dashcStats }: NavbarProps) {
             className="absolute inset-0 bg-black/50 backdrop-blur-sm"
             onClick={() => setIsMobileMenuOpen(false)}
           />
-          <div className="absolute top-0 right-0 h-full w-72 bg-slate-950/95 backdrop-blur-xl border-l border-white/10 p-6">
+          <div className="absolute top-0 right-0 h-full w-80 bg-slate-950/95 backdrop-blur-xl border-l border-white/10 p-6">
             <div className="flex items-center justify-between mb-8">
               <span className="text-lg font-bold text-white">Menu</span>
               <button
@@ -157,7 +157,7 @@ interface NavLinkProps {
 }
 
 function NavLink({ href, active, children, external = false, highlight = false, icon: Icon }: NavLinkProps) {
-  const baseClasses = "px-3 py-2 rounded-lg text-sm font-medium transition-all duration-200";
+  const baseClasses = "px-4 py-2 rounded-lg text-sm font-medium transition-all duration-200";
   
   const stateClasses = active
     ? "bg-teal-600/20 text-white border border-teal-500/30"
@@ -183,7 +183,7 @@ interface MobileNavLinkProps extends NavLinkProps {
 }
 
 function MobileNavLink({ href, active, children, external = false, highlight = false, icon: Icon, onClick }: MobileNavLinkProps) {
-  const baseClasses = "flex items-center gap-3 w-full p-3 rounded-lg text-sm font-medium transition-all duration-200";
+  const baseClasses = "flex items-center gap-3 w-full px-4 py-3 rounded-lg text-sm font-medium transition-all duration-200";
   
   const stateClasses = active
     ? "bg-teal-600/20 text-white border border-teal-500/30"


### PR DESCRIPTION
## Summary
- replace text in `DashcoinLogo` with small image
- standardize NavBar across all pages
- move stats bar out of NavBar on home page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844874cf58c832cb26e5ed983220735