### PR TITLE
Improve token comparison and creator wallet pages

### DIFF
--- a/app/compare/page.tsx
+++ b/app/compare/page.tsx
@@ -485,7 +485,7 @@ export default function ComparePage() {
             Advanced Token Comparison
           </div>
           
-          <h1 className="text-5xl md:text-6xl font-bold bg-gradient-to-r from-white via-teal-200 to-green-200 bg-clip-text text-transparent mb-6">
+          <h1 className="text-4xl md:text-5xl font-bold bg-gradient-to-r from-white via-teal-200 to-green-200 bg-clip-text text-transparent mb-6">
             Token Comparison
           </h1>
           
@@ -864,19 +864,19 @@ export default function ComparePage() {
                   <table className="w-full">
                     <thead>
                       <tr className="border-b border-white/10">
-                        <th className="text-left py-4 px-4 font-semibold text-white">Metric</th>
-                        <th className="text-right py-4 px-4 font-semibold text-white">{comparisonData.token1.symbol}</th>
-                        <th className="text-right py-4 px-4 font-semibold text-white">{comparisonData.token2.symbol}</th>
-                        <th className="text-right py-4 px-4 font-semibold text-white">Difference</th>
+                        <th className="text-left py-2 px-3 font-semibold text-white">Metric</th>
+                        <th className="text-right py-2 px-3 font-semibold text-white">{comparisonData.token1.symbol}</th>
+                        <th className="text-right py-2 px-3 font-semibold text-white">{comparisonData.token2.symbol}</th>
+                        <th className="text-right py-2 px-3 font-semibold text-white">Difference</th>
                       </tr>
                     </thead>
                     <tbody className="text-sm">
                       <tr className="border-b border-white/10 hover:bg-white/5 transition-colors">
-                        <td className="py-4 px-4 text-slate-300">Market Cap</td>
-                        <td className={`text-right py-4 px-4 ${comparisonData.token1.marketCap > comparisonData.token2.marketCap ? 'text-emerald-400 bg-emerald-500/10' : 'text-white'} rounded-lg`}>
+                        <td className="py-2 px-3 text-slate-300">Market Cap</td>
+                        <td className={`text-right py-2 px-3 ${comparisonData.token1.marketCap > comparisonData.token2.marketCap ? 'text-emerald-400 bg-emerald-500/10' : 'text-white'} rounded-lg`}>
                           ${comparisonData.token1.marketCap.toLocaleString()}
                         </td>
-                        <td className={`text-right py-4 px-4 ${comparisonData.token2.marketCap > comparisonData.token1.marketCap ? 'text-emerald-400 bg-emerald-500/10' : 'text-white'} rounded-lg`}>
+                        <td className={`text-right py-2 px-3 ${comparisonData.token2.marketCap > comparisonData.token1.marketCap ? 'text-emerald-400 bg-emerald-500/10' : 'text-white'} rounded-lg`}>
                           ${comparisonData.token2.marketCap.toLocaleString()}
                         </td>
                         {(() => {
@@ -885,7 +885,7 @@ export default function ComparePage() {
                           const multipleStr = calculateMultiple(v1, v2);
                           const colorClass = getDifferenceColorClass(v1, v2, multipleStr);
                           return (
-                            <td className={`text-right py-4 px-4 font-medium ${colorClass}`}>
+                            <td className={`text-right py-2 px-3 font-medium ${colorClass}`}>
                               {multipleStr}
                             </td>
                           );
@@ -893,11 +893,11 @@ export default function ComparePage() {
                       </tr>
                       
                       <tr className="border-b border-white/10 hover:bg-white/5 transition-colors">
-                        <td className="py-4 px-4 text-slate-300">Holders</td>
-                        <td className={`text-right py-4 px-4 ${comparisonData.token1.holders > comparisonData.token2.holders ? 'text-emerald-400 bg-emerald-500/10' : 'text-white'} rounded-lg`}>
+                        <td className="py-2 px-3 text-slate-300">Holders</td>
+                        <td className={`text-right py-2 px-3 ${comparisonData.token1.holders > comparisonData.token2.holders ? 'text-emerald-400 bg-emerald-500/10' : 'text-white'} rounded-lg`}>
                           {comparisonData.token1.holders.toLocaleString()}
                         </td>
-                        <td className={`text-right py-4 px-4 ${comparisonData.token2.holders > comparisonData.token1.holders ? 'text-emerald-400 bg-emerald-500/10' : 'text-white'} rounded-lg`}>
+                        <td className={`text-right py-2 px-3 ${comparisonData.token2.holders > comparisonData.token1.holders ? 'text-emerald-400 bg-emerald-500/10' : 'text-white'} rounded-lg`}>
                           {comparisonData.token2.holders.toLocaleString()}
                         </td>
                         {(() => {
@@ -906,7 +906,7 @@ export default function ComparePage() {
                           const multipleStr = calculateMultiple(v1, v2);
                           const colorClass = getDifferenceColorClass(v1, v2, multipleStr);
                           return (
-                            <td className={`text-right py-4 px-4 font-medium ${colorClass}`}>
+                            <td className={`text-right py-2 px-3 font-medium ${colorClass}`}>
                               {multipleStr}
                             </td>
                           );
@@ -914,11 +914,11 @@ export default function ComparePage() {
                       </tr>
                       
                       <tr className="border-b border-white/10 hover:bg-white/5 transition-colors">
-                        <td className="py-4 px-4 text-slate-300">Total Volume</td>
-                        <td className={`text-right py-4 px-4 ${comparisonData.token1.volume24h > comparisonData.token2.volume24h ? 'text-emerald-400 bg-emerald-500/10' : 'text-white'} rounded-lg`}>
+                        <td className="py-2 px-3 text-slate-300">Total Volume</td>
+                        <td className={`text-right py-2 px-3 ${comparisonData.token1.volume24h > comparisonData.token2.volume24h ? 'text-emerald-400 bg-emerald-500/10' : 'text-white'} rounded-lg`}>
                           ${comparisonData.token1.volume24h.toLocaleString()}
                         </td>
-                        <td className={`text-right py-4 px-4 ${comparisonData.token2.volume24h > comparisonData.token1.volume24h ? 'text-emerald-400 bg-emerald-500/10' : 'text-white'} rounded-lg`}>
+                        <td className={`text-right py-2 px-3 ${comparisonData.token2.volume24h > comparisonData.token1.volume24h ? 'text-emerald-400 bg-emerald-500/10' : 'text-white'} rounded-lg`}>
                           ${comparisonData.token2.volume24h.toLocaleString()}
                         </td>
                         {(() => {
@@ -927,7 +927,7 @@ export default function ComparePage() {
                           const multipleStr = calculateMultiple(v1, v2);
                           const colorClass = getDifferenceColorClass(v1, v2, multipleStr);
                           return (
-                            <td className={`text-right py-4 px-4 font-medium ${colorClass}`}>
+                            <td className={`text-right py-2 px-3 font-medium ${colorClass}`}>
                               {multipleStr}
                             </td>
                           );
@@ -935,24 +935,24 @@ export default function ComparePage() {
                       </tr>
                       
                       <tr className="border-b border-white/10 hover:bg-white/5 transition-colors">
-                        <td className="py-4 px-4 text-slate-300">Launch Date</td>
-                        <td className="text-right py-4 px-4 text-white">
+                        <td className="py-2 px-3 text-slate-300">Launch Date</td>
+                        <td className="text-right py-2 px-3 text-white">
                           {new Date(comparisonData.token1.launchDate).toLocaleDateString()}
                         </td>
-                        <td className="text-right py-4 px-4 text-white">
+                        <td className="text-right py-2 px-3 text-white">
                           {new Date(comparisonData.token2.launchDate).toLocaleDateString()}
                         </td>
-                        <td className="text-right py-4 px-4 text-slate-400">
+                        <td className="text-right py-2 px-3 text-slate-400">
                           {Math.abs(Math.floor((new Date(comparisonData.token1.launchDate).getTime() - new Date(comparisonData.token2.launchDate).getTime()) / (1000 * 60 * 60 * 24)))} days
                         </td>
                       </tr>
                       
                       <tr className="border-b border-white/10 hover:bg-white/5 transition-colors">
-                        <td className="py-4 px-4 text-slate-300">MarketCap Growth/Day</td>
-                        <td className={`text-right py-4 px-4 ${comparisonData.token1.marketcapgrowthperday > comparisonData.token2.marketcapgrowthperday ? 'text-emerald-400 bg-emerald-500/10' : 'text-white'} rounded-lg`}>
+                        <td className="py-2 px-3 text-slate-300">MarketCap Growth/Day</td>
+                        <td className={`text-right py-2 px-3 ${comparisonData.token1.marketcapgrowthperday > comparisonData.token2.marketcapgrowthperday ? 'text-emerald-400 bg-emerald-500/10' : 'text-white'} rounded-lg`}>
                           ${comparisonData.token1.marketcapgrowthperday.toLocaleString()}
                         </td>
-                        <td className={`text-right py-4 px-4 ${comparisonData.token2.marketcapgrowthperday > comparisonData.token1.marketcapgrowthperday ? 'text-emerald-400 bg-emerald-500/10' : 'text-white'} rounded-lg`}>
+                        <td className={`text-right py-2 px-3 ${comparisonData.token2.marketcapgrowthperday > comparisonData.token1.marketcapgrowthperday ? 'text-emerald-400 bg-emerald-500/10' : 'text-white'} rounded-lg`}>
                           ${comparisonData.token2.marketcapgrowthperday.toLocaleString()}
                         </td>
                         {(() => {
@@ -961,7 +961,7 @@ export default function ComparePage() {
                           const multipleStr = calculateMultiple(v1, v2);
                           const colorClass = getDifferenceColorClass(v1, v2, multipleStr);
                           return (
-                            <td className={`text-right py-4 px-4 font-medium ${colorClass}`}>
+                            <td className={`text-right py-2 px-3 font-medium ${colorClass}`}>
                               {multipleStr}
                             </td>
                           );
@@ -969,11 +969,11 @@ export default function ComparePage() {
                       </tr>
                       
                       <tr className="hover:bg-white/5 transition-colors">
-                        <td className="py-4 px-4 text-slate-300">Market Cap per Holder</td>
-                        <td className={`text-right py-4 px-4 ${comparisonData.token1.marketCap/comparisonData.token1.holders > comparisonData.token2.marketCap/comparisonData.token2.holders ? 'text-emerald-400 bg-emerald-500/10' : 'text-white'} rounded-lg`}>
+                        <td className="py-2 px-3 text-slate-300">Market Cap per Holder</td>
+                        <td className={`text-right py-2 px-3 ${comparisonData.token1.marketCap/comparisonData.token1.holders > comparisonData.token2.marketCap/comparisonData.token2.holders ? 'text-emerald-400 bg-emerald-500/10' : 'text-white'} rounded-lg`}>
                           ${(comparisonData.token1.marketCap/comparisonData.token1.holders).toLocaleString()}
                         </td>
-                        <td className={`text-right py-4 px-4 ${comparisonData.token2.marketCap/comparisonData.token2.holders > comparisonData.token1.marketCap/comparisonData.token1.holders ? 'text-emerald-400 bg-emerald-500/10' : 'text-white'} rounded-lg`}>
+                        <td className={`text-right py-2 px-3 ${comparisonData.token2.marketCap/comparisonData.token2.holders > comparisonData.token1.marketCap/comparisonData.token1.holders ? 'text-emerald-400 bg-emerald-500/10' : 'text-white'} rounded-lg`}>
                           ${(comparisonData.token2.marketCap/comparisonData.token2.holders).toLocaleString()}
                         </td>
                         {(() => {
@@ -982,7 +982,7 @@ export default function ComparePage() {
                           const multipleStr = calculateMultiple(v1, v2);
                           const colorClass = getDifferenceColorClass(v1, v2, multipleStr);
                           return (
-                            <td className={`text-right py-4 px-4 font-medium ${colorClass}`}>
+                            <td className={`text-right py-2 px-3 font-medium ${colorClass}`}>
                               {multipleStr}
                             </td>
                           );

--- a/app/creator-wallets/page.tsx
+++ b/app/creator-wallets/page.tsx
@@ -3,10 +3,10 @@ import Image from "next/image";
 import { fetchAllTokensFromDune } from "../actions/dune-actions";
 import { fetchCreatorWalletLinks } from "../actions/googlesheet-action";
 import { fetchDexscreenerTokenLogo } from "../actions/dexscreener-actions";
-import { 
-  ExternalLink, 
-  Wallet, 
-  Activity, 
+import { CreatorWalletList } from "@/components/creator-wallet-list";
+import {
+  Wallet,
+  Activity,
   Search,
   Filter,
   RefreshCw,
@@ -76,7 +76,7 @@ export default async function CreatorWalletsPage() {
               <div className="w-2 h-2 bg-teal-400 rounded-full animate-pulse delay-500"></div>
             </div>
             
-            <h1 className="text-4xl md:text-6xl lg:text-7xl font-bold bg-gradient-to-r from-white via-teal-100 to-emerald-200 bg-clip-text text-transparent mb-6 tracking-tight leading-tight">
+            <h1 className="text-3xl md:text-4xl lg:text-5xl font-bold bg-gradient-to-r from-white via-teal-100 to-emerald-200 bg-clip-text text-transparent mb-6 tracking-tight leading-tight">
               Creator Wallets
             </h1>
             
@@ -136,72 +136,7 @@ export default async function CreatorWalletsPage() {
               </div>
 
               {/* Table Body */}
-              <div className="divide-y divide-white/[0.05]">
-                {tokensWithWallets.map((token, index) => (
-                  <div key={`${token.symbol}-${index}`} className="group px-8 py-6 hover:bg-white/[0.02] transition-all duration-200">
-                    <div className="grid grid-cols-12 gap-6 items-center">
-                      {/* Token Info */}
-                      <div className="col-span-4">
-                        <div className="flex items-center gap-4">
-                          <div className="w-12 h-12 bg-gradient-to-br from-teal-500 to-green-500 rounded-xl flex items-center justify-center text-white font-bold text-sm overflow-hidden">
-                            {token.tokenUrl ? (
-                              <Image
-                                src={token.tokenUrl}
-                                alt={`${token.symbol} logo`}
-                                width={48}
-                                height={48}
-                                className="w-12 h-12 object-cover"
-                              />
-                            ) : (
-                              token.symbol.slice(0, 2).toUpperCase()
-                            )}
-                          </div>
-                          <div>
-                            <h3 className="font-semibold text-white text-lg tracking-tight">{token.name}</h3>
-                            <p className="text-slate-400 text-sm">{token.symbol}</p>
-                          </div>
-                        </div>
-                      </div>
-
-                      {/* Wallet Link */}
-                      <div className="col-span-4">
-                        {token.walletLink ? (
-                          <a 
-                            href={token.walletLink} 
-                            target="_blank" 
-                            rel="noopener noreferrer" 
-                            className="group/link inline-flex items-center gap-3 px-4 py-2.5 bg-teal-500/10 hover:bg-teal-500/20 border border-teal-500/20 hover:border-teal-500/30 rounded-xl text-teal-400 hover:text-teal-300 transition-all duration-200 font-medium"
-                          >
-                            <Wallet className="w-4 h-4" />
-                            <span>View Wallet</span>
-                            <ArrowUpRight className="w-4 h-4 group-hover/link:translate-x-0.5 group-hover/link:-translate-y-0.5 transition-transform" />
-                          </a>
-                        ) : (
-                          <div className="flex items-center gap-3 px-4 py-2.5 bg-slate-500/5 border border-slate-500/10 rounded-xl text-slate-500">
-                            <AlertCircle className="w-4 h-4" />
-                            <span>No wallet linked</span>
-                          </div>
-                        )}
-                      </div>
-
-                      {/* Activity */}
-                      <div className="col-span-4">
-                        {token.walletActivity ? (
-                          <div className="flex items-start gap-3 p-3 bg-emerald-500/5 border border-emerald-500/10 rounded-xl">
-                            <Activity className="w-4 h-4 text-emerald-400 mt-0.5 flex-shrink-0" />
-                            <p className="text-sm text-slate-300 leading-relaxed">{token.walletActivity}</p>
-                          </div>
-                        ) : (
-                          <div className="flex items-center gap-3 p-3 bg-slate-500/5 border border-slate-500/10 rounded-xl text-slate-500">
-                            <Clock className="w-4 h-4" />
-                            <span className="text-sm">No recent activity</span>
-                          </div>
-                        )}
-                      </div>
-                    </div>
-                  </div>
-                ))}
-              </div>
+              <CreatorWalletList tokens={tokensWithWallets} />
             </div>
           ) : (
             <div className="text-center py-20">

--- a/components/creator-wallet-list.tsx
+++ b/components/creator-wallet-list.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import Image from "next/image";
+import { Wallet, AlertCircle, Activity, Clock, ArrowUpRight } from "lucide-react";
+
+interface TokenWalletInfo {
+  name: string;
+  symbol: string;
+  tokenUrl: string;
+  walletLink: string;
+  walletActivity: string;
+}
+
+export function CreatorWalletList({ tokens }: { tokens: TokenWalletInfo[] }) {
+  const [sort, setSort] = useState<"trending" | "active">("trending");
+  const [page, setPage] = useState(1);
+  const pageSize = 10;
+
+  const sortedTokens = useMemo(() => {
+    const arr = [...tokens];
+    if (sort === "active") {
+      arr.sort(
+        (a, b) =>
+          (b.walletActivity ? b.walletActivity.length : 0) -
+          (a.walletActivity ? a.walletActivity.length : 0)
+      );
+    }
+    return arr;
+  }, [tokens, sort]);
+
+  const totalPages = Math.ceil(sortedTokens.length / pageSize) || 1;
+  const pageTokens = sortedTokens.slice(
+    (page - 1) * pageSize,
+    page * pageSize
+  );
+
+  const handlePrev = () => setPage((p) => Math.max(1, p - 1));
+  const handleNext = () => setPage((p) => Math.min(totalPages, p + 1));
+
+  return (
+    <>
+      <div className="flex justify-end mb-4 gap-2">
+        <label htmlFor="sort" className="text-sm text-slate-400">
+          Sort:
+        </label>
+        <select
+          id="sort"
+          value={sort}
+          onChange={(e) => {
+            setSort(e.target.value as "trending" | "active");
+            setPage(1);
+          }}
+          className="px-3 py-2 bg-white/[0.03] border border-white/10 rounded-xl text-sm text-white backdrop-blur-xl"
+        >
+          <option value="trending">Trending</option>
+          <option value="active">Most Active</option>
+        </select>
+      </div>
+      <div className="divide-y divide-white/[0.05]">
+        {pageTokens.map((token, index) => (
+          <div
+            key={`${token.symbol}-${index}`}
+            className="group px-8 py-6 hover:bg-white/[0.02] transition-all duration-200"
+          >
+            <div className="grid grid-cols-12 gap-6 items-center">
+              <div className="col-span-4">
+                <div className="flex items-center gap-4">
+                  <div className="w-12 h-12 bg-gradient-to-br from-teal-500 to-green-500 rounded-xl flex items-center justify-center text-white font-bold text-sm overflow-hidden">
+                    {token.tokenUrl ? (
+                      <Image
+                        src={token.tokenUrl}
+                        alt={`${token.symbol} logo`}
+                        width={48}
+                        height={48}
+                        className="w-12 h-12 object-cover"
+                      />
+                    ) : (
+                      token.symbol.slice(0, 2).toUpperCase()
+                    )}
+                  </div>
+                  <div>
+                    <h3 className="font-semibold text-white text-lg tracking-tight">
+                      {token.name}
+                    </h3>
+                    <p className="text-slate-400 text-sm">{token.symbol}</p>
+                  </div>
+                </div>
+              </div>
+              <div className="col-span-4">
+                {token.walletLink ? (
+                  <a
+                    href={token.walletLink}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="group/link inline-flex items-center gap-3 px-4 py-2.5 bg-teal-500/10 hover:bg-teal-500/20 border border-teal-500/20 hover:border-teal-500/30 rounded-xl text-teal-400 hover:text-teal-300 transition-all duration-200 font-medium"
+                  >
+                    <Wallet className="w-4 h-4" />
+                    <span>View Wallet</span>
+                    <ArrowUpRight className="w-4 h-4 group-hover/link:translate-x-0.5 group-hover/link:-translate-y-0.5 transition-transform" />
+                  </a>
+                ) : (
+                  <div className="flex items-center gap-3 px-4 py-2.5 bg-slate-500/5 border border-slate-500/10 rounded-xl text-slate-500">
+                    <AlertCircle className="w-4 h-4" />
+                    <span>No wallet linked</span>
+                  </div>
+                )}
+              </div>
+              <div className="col-span-4">
+                {token.walletActivity ? (
+                  <div className="flex items-start gap-3 p-3 bg-emerald-500/5 border border-emerald-500/10 rounded-xl">
+                    <Activity className="w-4 h-4 text-emerald-400 mt-0.5 flex-shrink-0" />
+                    <p className="text-sm text-slate-300 leading-relaxed">
+                      {token.walletActivity}
+                    </p>
+                  </div>
+                ) : (
+                  <div className="flex items-center gap-3 p-3 bg-slate-500/5 border border-slate-500/10 rounded-xl text-slate-500">
+                    <Clock className="w-4 h-4" />
+                    <span className="text-sm">No recent activity</span>
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+      <div className="flex justify-center items-center gap-4 py-6">
+        <button
+          onClick={handlePrev}
+          disabled={page === 1}
+          className="px-3 py-1 bg-white/[0.03] border border-white/10 rounded-lg text-white disabled:opacity-50"
+        >
+          Prev
+        </button>
+        <span className="text-sm text-slate-400">
+          Page {page} of {totalPages}
+        </span>
+        <button
+          onClick={handleNext}
+          disabled={page === totalPages}
+          className="px-3 py-1 bg-white/[0.03] border border-white/10 rounded-lg text-white disabled:opacity-50"
+        >
+          Next
+        </button>
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- reduce header size for token comparison
- shrink table spacing on comparison results
- implement CreatorWalletList with pagination and sorting
- use new list on creator wallets page and trim header size

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844875c4210832ca0d3da45f24d4a9b