### PR TITLE
Move trade info out of navbar

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,6 +21,7 @@ import { formatCurrency, formatCurrency0 } from "@/lib/utils";
 import EnvSetup from "./env-setup";
 import { Suspense } from "react";
 import { Navbar } from "@/components/navbar";
+import { DashcStatsBar } from "@/components/dashc-stats-bar";
 import {
   Twitter,
   TrendingUp,
@@ -303,13 +304,7 @@ export default async function Home() {
 
       {/* Navigation */}
       <div className="relative z-50">
-        <Navbar
-          dashcStats={{
-            tradeLink: dashcoinTradeLink,
-            marketCap: dashcMarketCap,
-            contractAddress: dashcoinCA,
-          }}
-        />
+        <Navbar />
       </div>
 
       <main className="relative z-10 container mx-auto px-4 py-8 max-w-7xl mt-16 mt-16">
@@ -388,6 +383,15 @@ export default async function Home() {
               changeType="positive"
             />
           </div>
+        </section>
+
+        {/* Trade Dashcoin Section */}
+        <section className="mb-12 flex justify-center">
+          <DashcStatsBar
+            tradeLink={dashcoinTradeLink}
+            marketCap={dashcMarketCap}
+            contractAddress={dashcoinCA}
+          />
         </section>
 
         {/* Market Overview Section */}

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useState, useEffect } from "react";
 import { DashcoinLogo } from "@/components/dashcoin-logo";
-import { DashcStatsBar, DashcStatsBarProps } from "@/components/dashc-stats-bar";
+
 import { 
   Menu, 
   X, 
@@ -17,11 +17,7 @@ import {
   Users 
 } from "lucide-react";
 
-interface NavbarProps {
-  dashcStats?: DashcStatsBarProps;
-}
-
-export function Navbar({ dashcStats }: NavbarProps) {
+export function Navbar() {
   const pathname = usePathname();
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const [isScrolled, setIsScrolled] = useState(false);
@@ -62,13 +58,6 @@ export function Navbar({ dashcStats }: NavbarProps) {
                 <DashcoinLogo size={40} />
               </Link>
 
-            {/* Compact Stats Bar - Center */}
-            {dashcStats && (
-              <div className="hidden md:block flex-1 max-w-md mx-8">
-                <DashcStatsBar {...dashcStats} />
-              </div>
-            )}
-
             </div>
 
 
@@ -98,12 +87,6 @@ export function Navbar({ dashcStats }: NavbarProps) {
             </button>
           </div>
 
-          {/* Mobile Stats Bar */}
-          {dashcStats && (
-            <div className="md:hidden pb-4">
-              <DashcStatsBar {...dashcStats} />
-            </div>
-          )}
         </div>
       </header>
 

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -50,8 +50,8 @@ export function Navbar() {
             : 'bg-slate-950'
         }`}
       >
-        <div className="max-w-9xl mx-auto px-4">
-          <div className="flex items-center justify-between h-16">
+        <div className="w-full px-4 sm:px-6 lg:px-8">
+          <div className="flex items-center justify-between h-16 max-w-7xl mx-auto">
             {/* Logo */}
             <div className="flex items-center">
               <Link href="/" className="flex items-center gap-3">


### PR DESCRIPTION
## Summary
- strip trade stats from `Navbar`
- import and display `DashcStatsBar` on the homepage below the hero section
- call `<Navbar />` consistently across pages

## Testing
- `npm test`
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6844993d3158832cb390274d372f73e3