### PR TITLE
Fix Dexscreener data flicker

### DIFF
--- a/components/token-search-list.tsx
+++ b/components/token-search-list.tsx
@@ -203,9 +203,16 @@ export default function TokenSearchList() {
     return filteredAndSortedTokens.slice(start, start + pageSize);
   }, [filteredAndSortedTokens, currentPage, pageSize]);
 
+  // Only refetch Dexscreener data when the set of token addresses changes
+  const paginatedTokenKey = useMemo(
+    () => paginatedTokens.map((t) => t.token).join(','),
+    [paginatedTokens],
+  );
+
   useEffect(() => {
     fetchDexData(paginatedTokens);
-  }, [paginatedTokens, fetchDexData]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [paginatedTokenKey, fetchDexData]);
 
   useEffect(() => {
     if (currentPage > totalPages) {


### PR DESCRIPTION
## Summary
- avoid re-fetching Dexscreener data whenever state updates

## Testing
- `bash setup.sh` *(fails: 403 Forbidden for npm registry)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68449c61d9cc832c9c33569780e041b6