### PR TITLE
Fix token table data loading on pagination

### DIFF
--- a/components/token-table.tsx
+++ b/components/token-table.tsx
@@ -308,10 +308,15 @@ export default function TokenTable({ data }: { data: PaginatedTokenResponse | To
     
     return () => clearTimeout(timer);
   }, [refreshCountdown, fetchDexscreenerData]);
-  
+
   useEffect(() => {
     fetchDexscreenerData();
   }, [currentPage, fetchDexscreenerData]);
+
+  // Fetch fresh Dexscreener data whenever the set of tokens changes
+  useEffect(() => {
+    fetchDexscreenerData();
+  }, [filteredTokens, fetchDexscreenerData]);
 
   useEffect(() => {
     if (searchTerm !== "" && currentPage !== 1) {


### PR DESCRIPTION
## Summary
- ensure Dexscreener data refreshes whenever paginated tokens change

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844e11eb1b8832cad63c8c9df718526