### PR TITLE
Fix token table pagination fetch

### DIFF
--- a/app/api/paginated-tokens/route.ts
+++ b/app/api/paginated-tokens/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+import { fetchPaginatedTokens } from '@/app/actions/dune-actions';
+
+export async function GET(req: Request) {
+  try {
+    const { searchParams } = new URL(req.url);
+    const page = parseInt(searchParams.get('page') || '1', 10);
+    const pageSize = parseInt(searchParams.get('pageSize') || '10', 10);
+    const sortField = searchParams.get('sortField') || 'marketCap';
+    const sortDirection = searchParams.get('sortDirection') || 'desc';
+    const searchTerm = searchParams.get('searchTerm') || '';
+
+    const data = await fetchPaginatedTokens(page, pageSize, sortField, sortDirection, searchTerm);
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('Error fetching paginated tokens:', error);
+    return new NextResponse(JSON.stringify({ error: 'Failed to fetch paginated tokens' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+}

--- a/components/token-table.tsx
+++ b/components/token-table.tsx
@@ -27,7 +27,6 @@ import {
   TooltipContent,
   TooltipProvider,
 } from "@/components/ui/tooltip"
-import { fetchPaginatedTokens } from "@/app/actions/dune-actions"
 import type { TokenData, PaginatedTokenResponse } from "@/types/dune"
 import { CopyAddress } from "@/components/copy-address"
 import { batchFetchTokensData } from "@/app/actions/dexscreener-actions"
@@ -210,23 +209,26 @@ export default function TokenTable({ data }: { data: PaginatedTokenResponse | To
   }, [checklistFilters])
 
   const fetchData = async () => {
-    setIsLoading(true);
+    setIsLoading(true)
     try {
-      const newData = await fetchPaginatedTokens(
-        currentPage, 
-        itemsPerPage, 
-        sortField, 
+      const params = new URLSearchParams({
+        page: String(currentPage),
+        pageSize: String(itemsPerPage),
+        sortField,
         sortDirection,
-        searchTerm 
-      );
-      setTokenData(newData);
-      setFilteredTokens(newData.tokens || []);
+        searchTerm,
+      })
+      const res = await fetch(`/api/paginated-tokens?${params.toString()}`)
+      if (!res.ok) throw new Error('Failed to fetch')
+      const newData: PaginatedTokenResponse = await res.json()
+      setTokenData(newData)
+      setFilteredTokens(newData.tokens || [])
     } catch (error) {
-      console.error("Error fetching paginated tokens:", error);
+      console.error('Error fetching paginated tokens:', error)
     } finally {
-      setIsLoading(false);
+      setIsLoading(false)
     }
-  };
+  }
 
   const fetchDexscreenerData = useCallback(async () => {
     if (!filteredTokens.length) return;


### PR DESCRIPTION
## Summary
- provide API route to fetch paginated tokens
- use new API route inside `TokenTable`

## Testing
- `npm test`
- `npx tsc -p tsconfig.json` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6844e34e5ba8832c941e60852dfef144