### PR TITLE
Improve market overview charts

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -27,14 +27,11 @@ import {
   DollarSign,
   Activity,
   BarChart3,
-  PieChart,
   Zap,
   Search,
   Filter,
   ArrowUpRight,
-  Clock,
   Users,
-  Target,
   Sparkles,
   ChevronRight,
   ExternalLink,
@@ -42,8 +39,9 @@ import {
   AlertCircle,
   TrendingDown,
   ArrowUp,
-  ArrowDown
+  ArrowDown,
 } from "lucide-react";
+import { MarketCapTrendCard, MarketCapDistributionCard } from "@/components/market-overview-charts";
 
 const MarketCapChartWrapper = async ({
   marketCapTimeDataPromise,
@@ -52,26 +50,7 @@ const MarketCapChartWrapper = async ({
 }) => {
   try {
     const marketCapTimeData = await marketCapTimeDataPromise;
-    return (
-      <div className="h-full">
-        <div className="flex items-center justify-between mb-6">
-          <div className="flex items-center gap-3">
-            <div className="p-2 bg-gradient-to-r from-teal-500 to-teal-600 rounded-lg">
-              <TrendingUp className="w-5 h-5 text-white" />
-            </div>
-            <div>
-              <h3 className="text-lg font-semibold text-white">Market Cap Trend</h3>
-              <p className="text-sm text-slate-400">Last 30 days performance</p>
-            </div>
-          </div>
-          <div className="flex items-center gap-2 text-xs text-slate-400">
-            <Clock className="w-4 h-4" />
-            <span>Real-time</span>
-          </div>
-        </div>
-        <MarketCapChart data={marketCapTimeData || []} />
-      </div>
-    );
+    return <MarketCapTrendCard data={marketCapTimeData || []} />;
   } catch (error) {
     console.error("Error in MarketCapChartWrapper:", error);
     return (
@@ -93,26 +72,7 @@ const MarketCapPieWrapper = async ({
 }) => {
   try {
     const tokenMarketCaps = await tokenMarketCapsPromise;
-    return (
-      <div className="h-full">
-        <div className="flex items-center justify-between mb-6">
-          <div className="flex items-center gap-3">
-            <div className="p-2 bg-gradient-to-r from-emerald-500 to-teal-500 rounded-lg">
-              <PieChart className="w-5 h-5 text-white" />
-            </div>
-            <div>
-              <h3 className="text-lg font-semibold text-white">Market Distribution</h3>
-              <p className="text-sm text-slate-400">Top tokens by market cap</p>
-            </div>
-          </div>
-          <div className="flex items-center gap-2 text-xs text-slate-400">
-            <Target className="w-4 h-4" />
-            <span>Live data</span>
-          </div>
-        </div>
-        <MarketCapPie data={tokenMarketCaps || []} />
-      </div>
-    );
+    return <MarketCapDistributionCard data={tokenMarketCaps || []} />;
   } catch (error) {
     console.error("Error in MarketCapPieWrapper:", error);
     return (
@@ -408,33 +368,27 @@ export default async function Home() {
           </div>
 
           {/* Charts Grid */}
-          <div className="grid grid-cols-1 xl:grid-cols-2 gap-8 mb-8">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-8 mb-8">
             <Suspense
               fallback={
-                <div className="bg-white/5 border border-white/10 rounded-2xl p-8 h-96 flex items-center justify-center">
-                  <div className="flex items-center gap-3">
-                    <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-teal-400"></div>
-                    <p className="text-slate-300">Loading market trends...</p>
-                  </div>
+                <div className="bg-white/5 border border-white/10 rounded-2xl p-8 h-96">
+                  <div className="h-full w-full animate-pulse rounded-lg bg-slate-800" />
                 </div>
               }
             >
-              <div className="bg-white/5 backdrop-blur-xl border border-white/10 rounded-2xl p-8 hover:bg-white/[0.07] transition-all duration-300 h-full">
+              <div className="bg-white/5 backdrop-blur-xl border border-white/10 rounded-2xl p-8 hover:bg-white/[0.07] transition-all duration-300 h-full overflow-hidden">
                 <MarketCapChartWrapper marketCapTimeDataPromise={marketCapTimeDataPromise} />
               </div>
             </Suspense>
             
             <Suspense
               fallback={
-                <div className="bg-white/5 border border-white/10 rounded-2xl p-8 h-96 flex items-center justify-center">
-                  <div className="flex items-center gap-3">
-                    <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-green-400"></div>
-                    <p className="text-slate-300">Loading distribution data...</p>
-                  </div>
+                <div className="bg-white/5 border border-white/10 rounded-2xl p-8 h-96">
+                  <div className="h-full w-full animate-pulse rounded-lg bg-slate-800" />
                 </div>
               }
             >
-              <div className="bg-white/5 backdrop-blur-xl border border-white/10 rounded-2xl p-8 hover:bg-white/[0.07] transition-all duration-300 h-full">
+              <div className="bg-white/5 backdrop-blur-xl border border-white/10 rounded-2xl p-8 hover:bg-white/[0.07] transition-all duration-300 h-full overflow-hidden">
                 <MarketCapPieWrapper tokenMarketCapsPromise={tokenMarketCapsPromise} />
               </div>
             </Suspense>

--- a/components/market-cap-chart.tsx
+++ b/components/market-cap-chart.tsx
@@ -1,9 +1,8 @@
 "use client"
 
-import { useEffect, useRef } from "react"
-import { DashcoinCard, DashcoinCardHeader, DashcoinCardTitle, DashcoinCardContent } from "@/components/ui/dashcoin-card"
+import { useEffect, useRef, forwardRef, useImperativeHandle } from "react"
 import type { MarketCapTimeData } from "@/types/dune"
-import { formatCurrency, getCssVariable, hexToRgba } from "@/lib/utils"
+import { formatCurrency, hexToRgba } from "@/lib/utils"
 
 declare global {
   interface Window {
@@ -15,9 +14,12 @@ interface MarketCapChartProps {
   data: MarketCapTimeData[]
 }
 
-export function MarketCapChart({ data }: MarketCapChartProps) {
-  const chartRef = useRef<HTMLCanvasElement>(null)
-  const chartInstance = useRef<any>(null)
+export const MarketCapChart = forwardRef<HTMLCanvasElement, MarketCapChartProps>(
+  ({ data }, ref) => {
+    const chartRef = useRef<HTMLCanvasElement>(null)
+    const chartInstance = useRef<any>(null)
+
+    useImperativeHandle(ref, () => chartRef.current as HTMLCanvasElement)
 
   const createChart = () => {
     if (chartInstance.current) {
@@ -36,6 +38,7 @@ export function MarketCapChart({ data }: MarketCapChartProps) {
     const dashYellow = "#50E3C2"
     const dashYellowLight = "#A0A0B0"
     const dashGreen = "#6A8DFF"
+    const gridColor = "#334155"
 
     const chartData = {
       labels: sortedData.map((item) => (item.date ? new Date(item.date).toLocaleDateString() : "Unknown")),
@@ -71,7 +74,7 @@ export function MarketCapChart({ data }: MarketCapChartProps) {
         scales: {
           x: {
             grid: {
-              color: "rgba(42, 47, 14, 0.3)",
+              color: gridColor,
             },
             ticks: {
               color: dashYellowLight,
@@ -79,7 +82,7 @@ export function MarketCapChart({ data }: MarketCapChartProps) {
           },
           y: {
             grid: {
-              color: "rgba(42, 47, 14, 0.3)",
+              color: gridColor,
             },
             ticks: {
               color: dashYellowLight,
@@ -105,6 +108,11 @@ export function MarketCapChart({ data }: MarketCapChartProps) {
             },
           },
           tooltip: {
+            backgroundColor: "#0f172a",
+            titleColor: "#f1f5f9",
+            bodyColor: "#f1f5f9",
+            borderColor: "#475569",
+            borderWidth: 1,
             callbacks: {
               label: (context: any) => {
                 const label = context.dataset.label || ""
@@ -147,15 +155,8 @@ export function MarketCapChart({ data }: MarketCapChartProps) {
   }, [data])
 
   return (
-    <DashcoinCard>
-      <DashcoinCardHeader>
-        <DashcoinCardTitle className="text-white">Market Cap & Holders Over Time</DashcoinCardTitle>
-      </DashcoinCardHeader>
-      <DashcoinCardContent>
-        <div className="h-64 bg-neutral-900 rounded-lg">
-          <canvas ref={chartRef} />
-        </div>
-      </DashcoinCardContent>
-    </DashcoinCard>
+    <div className="relative h-72 w-full">
+      <canvas ref={chartRef} className="!w-full !h-full" />
+    </div>
   )
-}
+})

--- a/components/market-cap-pie.tsx
+++ b/components/market-cap-pie.tsx
@@ -1,7 +1,6 @@
 "use client"
 
-import { useEffect, useRef } from "react"
-import { DashcoinCard, DashcoinCardHeader, DashcoinCardTitle, DashcoinCardContent } from "@/components/ui/dashcoin-card"
+import { useEffect, useRef, forwardRef, useImperativeHandle } from "react"
 import type { TokenMarketCapData } from "@/types/dune"
 import { formatCurrency } from "@/lib/utils"
 
@@ -22,10 +21,13 @@ interface MarketCapPieProps {
   data: TokenMarketCapData[]
 }
 
-export function MarketCapPie({ data }: MarketCapPieProps) {
-  const chartRef = useRef<HTMLCanvasElement>(null)
-  const chartInstance = useRef<any>(null)
-  const hasData = data && data.length > 0
+export const MarketCapPie = forwardRef<HTMLCanvasElement, MarketCapPieProps>(
+  ({ data }, ref) => {
+    const chartRef = useRef<HTMLCanvasElement>(null)
+    const chartInstance = useRef<any>(null)
+    const hasData = data && data.length > 0
+
+    useImperativeHandle(ref, () => chartRef.current as HTMLCanvasElement)
 
   useEffect(() => {
     if (!hasData) return
@@ -70,6 +72,8 @@ export function MarketCapPie({ data }: MarketCapPieProps) {
     if (topTokens.length === 0) return
 
     const dashYellowLight = "#A0A0B0"
+    const tooltipBg = "#0f172a"
+    const tooltipBorder = "#475569"
 
     const colors = palette
 
@@ -105,6 +109,11 @@ export function MarketCapPie({ data }: MarketCapPieProps) {
             },
           },
           tooltip: {
+            backgroundColor: tooltipBg,
+            titleColor: "#f1f5f9",
+            bodyColor: "#f1f5f9",
+            borderColor: tooltipBorder,
+            borderWidth: 1,
             callbacks: {
               label: (context: any) => {
                 const label = context.label || ""
@@ -121,21 +130,16 @@ export function MarketCapPie({ data }: MarketCapPieProps) {
   }
 
   return (
-    <DashcoinCard>
-      <DashcoinCardHeader>
-        <DashcoinCardTitle className="text-white">Market Cap Distribution</DashcoinCardTitle>
-      </DashcoinCardHeader>
-      <DashcoinCardContent>
-        {hasData ? (
-          <div className="min-h-[300px] p-4 bg-neutral-50 dark:bg-neutral-900 rounded-lg">
-            <canvas ref={chartRef} />
-          </div>
-        ) : (
-          <div className="min-h-[300px] flex items-center justify-center bg-neutral-50 dark:bg-neutral-900 rounded-lg">
-            <p>No market cap data available.</p>
-          </div>
-        )}
-      </DashcoinCardContent>
-    </DashcoinCard>
+    <div className="min-h-[300px] w-full">
+      {hasData ? (
+        <div className="relative h-72 rounded-lg bg-slate-900">
+          <canvas ref={chartRef} className="!w-full !h-full" />
+        </div>
+      ) : (
+        <div className="h-72 flex items-center justify-center rounded-lg bg-slate-900">
+          <p className="text-slate-400">No market cap data available.</p>
+        </div>
+      )}
+    </div>
   )
-}
+})

--- a/components/market-overview-charts.tsx
+++ b/components/market-overview-charts.tsx
@@ -1,0 +1,90 @@
+'use client'
+import { useRef } from 'react'
+import { TrendingUp, PieChart, Download, Info, Clock, Target } from 'lucide-react'
+import { MarketCapChart } from './market-cap-chart'
+import { MarketCapPie } from './market-cap-pie'
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip'
+
+export function MarketCapTrendCard({ data }: { data: any[] }) {
+  const chartRef = useRef<HTMLCanvasElement>(null)
+
+  const handleDownload = () => {
+    if (!chartRef.current) return
+    const link = document.createElement('a')
+    link.href = chartRef.current.toDataURL('image/png')
+    link.download = 'market-cap-trend.png'
+    link.click()
+  }
+
+  return (
+    <div className="h-full">
+      <div className="flex items-center justify-between mb-6">
+        <div className="flex items-center gap-3">
+          <div className="p-2 bg-gradient-to-r from-teal-500 to-teal-600 rounded-lg">
+            <TrendingUp className="w-5 h-5 text-white" />
+          </div>
+          <div>
+            <h3 className="text-lg font-semibold text-white">Market Cap Trend</h3>
+            <p className="text-sm text-slate-400">Last 30 days performance</p>
+          </div>
+        </div>
+        <div className="flex items-center gap-3">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Info className="w-4 h-4 text-slate-400 cursor-pointer" />
+            </TooltipTrigger>
+            <TooltipContent>Shows overall market cap and holders over time.</TooltipContent>
+          </Tooltip>
+          <div className="flex items-center gap-1 text-xs text-slate-400">
+            <Clock className="w-4 h-4" />
+            <span>Real-time</span>
+          </div>
+          <Download onClick={handleDownload} className="w-4 h-4 cursor-pointer text-slate-400 hover:text-slate-200" />
+        </div>
+      </div>
+      <MarketCapChart ref={chartRef} data={data} />
+    </div>
+  )
+}
+
+export function MarketCapDistributionCard({ data }: { data: any[] }) {
+  const chartRef = useRef<HTMLCanvasElement>(null)
+
+  const handleDownload = () => {
+    if (!chartRef.current) return
+    const link = document.createElement('a')
+    link.href = chartRef.current.toDataURL('image/png')
+    link.download = 'market-distribution.png'
+    link.click()
+  }
+
+  return (
+    <div className="h-full">
+      <div className="flex items-center justify-between mb-6">
+        <div className="flex items-center gap-3">
+          <div className="p-2 bg-gradient-to-r from-emerald-500 to-teal-500 rounded-lg">
+            <PieChart className="w-5 h-5 text-white" />
+          </div>
+          <div>
+            <h3 className="text-lg font-semibold text-white">Market Distribution</h3>
+            <p className="text-sm text-slate-400">Top tokens by market cap</p>
+          </div>
+        </div>
+        <div className="flex items-center gap-3">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Info className="w-4 h-4 text-slate-400 cursor-pointer" />
+            </TooltipTrigger>
+            <TooltipContent>Breakdown of market cap across leading tokens.</TooltipContent>
+          </Tooltip>
+          <div className="flex items-center gap-1 text-xs text-slate-400">
+            <Target className="w-4 h-4" />
+            <span>Live data</span>
+          </div>
+          <Download onClick={handleDownload} className="w-4 h-4 cursor-pointer text-slate-400 hover:text-slate-200" />
+        </div>
+      </div>
+      <MarketCapPie ref={chartRef} data={data} />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add new `MarketCapTrendCard` and `MarketCapDistributionCard` client components
- restyle Market Overview grid and loading states
- modernize `MarketCapChart`/`MarketCapPie` with dark tooltips and responsive canvas

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844db2578c4832c846e19f7ff85f684