### PR TITLE
Add research score tooltip in token table

### DIFF
--- a/components/token-search-list.tsx
+++ b/components/token-search-list.tsx
@@ -31,6 +31,14 @@ import {
   X
 } from "lucide-react";
 import { formatCurrency0 } from "@/lib/utils";
+import {
+  Tooltip,
+  TooltipTrigger,
+  TooltipContent,
+  TooltipProvider,
+} from "@/components/ui/tooltip";
+import { canonicalChecklist } from "@/components/founders-edge-checklist";
+import { gradeMaps, valueToScore } from "@/lib/score";
 import Link from "next/link";
 
 interface ResearchScoreData {
@@ -494,10 +502,31 @@ export default function TokenSearchList() {
                     </td>
                     <td className="py-4 px-6">
                       {token.score !== undefined && token.score !== null ? (
-                        <div className="flex items-center gap-1 px-2 py-1 bg-emerald-500/20 text-emerald-300 rounded-lg w-fit">
-                          <Star className="w-3 h-3" />
-                          <span className="font-bold">{token.score.toFixed(1)}</span>
-                        </div>
+                        <TooltipProvider delayDuration={100}>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <div className="flex items-center gap-1 px-2 py-1 bg-emerald-500/20 text-emerald-300 rounded-lg w-fit cursor-pointer">
+                                <Star className="w-3 h-3" />
+                                <span className="font-bold">{token.score.toFixed(1)}</span>
+                              </div>
+                            </TooltipTrigger>
+                            <TooltipContent side="top" className="text-left max-w-xs">
+                              <ul className="space-y-1">
+                                {canonicalChecklist.map(({ label, display }) => {
+                                  const raw = (token as any)[label]
+                                  const val = valueToScore(raw, (gradeMaps as any)[label])
+                                  const displayVal = val * 6
+                                  return (
+                                    <li key={label} className="flex justify-between gap-2">
+                                      <span>{display}</span>
+                                      <span className="font-semibold">+{displayVal}</span>
+                                    </li>
+                                  )
+                                })}
+                              </ul>
+                            </TooltipContent>
+                          </Tooltip>
+                        </TooltipProvider>
                       ) : (
                         <span className="text-slate-500">-</span>
                       )}

--- a/components/token-table.tsx
+++ b/components/token-table.tsx
@@ -33,6 +33,7 @@ import { CopyAddress } from "@/components/copy-address"
 import { batchFetchTokensData } from "@/app/actions/dexscreener-actions"
 import { fetchTokenResearch } from "@/app/actions/googlesheet-action"
 import { canonicalChecklist } from "@/components/founders-edge-checklist"
+import { gradeMaps, valueToScore } from "@/lib/score"
 import { researchFilterOptions } from "@/data/research-filter-options"
 import { useRouter, useSearchParams } from "next/navigation"
 
@@ -609,16 +610,37 @@ export default function TokenTable({ data }: { data: PaginatedTokenResponse | To
                             <span>Loading...</span>
                           </div>
                         ) : researchScore !== null && researchScore !== undefined ? (
-                          <div className="flex items-center">
-                            <span className="font-medium mr-2">{researchScore.toFixed(1)}</span>
-                            <Link
-                              href={`/tokendetail/${tokenSymbol}`}
-                              className="hover:text-dashYellow"
-                              onClick={(e) => e.stopPropagation()}
-                            >
-                              <FileSearch className="h-4 w-4" />
-                            </Link>
-                          </div>
+                          <TooltipProvider delayDuration={100}>
+                            <Tooltip>
+                              <TooltipTrigger asChild>
+                                <div className="flex items-center cursor-pointer">
+                                  <span className="font-medium mr-2">{researchScore.toFixed(1)}</span>
+                                  <Link
+                                    href={`/tokendetail/${tokenSymbol}`}
+                                    className="hover:text-dashYellow"
+                                    onClick={(e) => e.stopPropagation()}
+                                  >
+                                    <FileSearch className="h-4 w-4" />
+                                  </Link>
+                                </div>
+                              </TooltipTrigger>
+                              <TooltipContent className="text-left max-w-xs">
+                                <ul className="space-y-1">
+                                  {canonicalChecklist.map(({ label, display }) => {
+                                    const raw = (token as any)[label]
+                                    const val = valueToScore(raw, (gradeMaps as any)[label])
+                                    const displayVal = val * 6
+                                    return (
+                                      <li key={label} className="flex justify-between gap-2">
+                                        <span>{display}</span>
+                                        <span className="font-semibold">+{displayVal}</span>
+                                      </li>
+                                    )
+                                  })}
+                                </ul>
+                              </TooltipContent>
+                            </Tooltip>
+                          </TooltipProvider>
                         ) : (
                           <span className="text-dashYellow-light opacity-50">-</span>
                         )}


### PR DESCRIPTION
## Summary
- display breakdown tooltip for research score in the token table
- import scoring utilities for tooltip calculation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68452e21f744832cbb76efe89c61d6d5