### PR TITLE
Fix token table flicker

### DIFF
--- a/components/token-table.tsx
+++ b/components/token-table.tsx
@@ -71,6 +71,7 @@ export default function TokenTable({ data }: { data: PaginatedTokenResponse | To
   const [researchScores, setResearchScores] = useState<ResearchScoreData[]>([])
   const [isLoadingResearch, setIsLoadingResearch] = useState(false)
   const [dexscreenerData, setDexscreenerData] = useState<Record<string, any>>({})
+  const [isDexLoading, setIsDexLoading] = useState(false)
   const [lastRefreshed, setLastRefreshed] = useState<Date | null>(null)
   const searchParams = useSearchParams()
   const router = useRouter()
@@ -288,8 +289,9 @@ export default function TokenTable({ data }: { data: PaginatedTokenResponse | To
     if (tokenAddresses.length === 0) return;
     
     try {
-      const dataMap = await batchFetchTokensData(tokenAddresses);
-      const newDexData: Record<string, any> = {};
+      setIsDexLoading(true)
+      const dataMap = await batchFetchTokensData(tokenAddresses)
+      const newDexData: Record<string, any> = {}
       
       tokenAddresses.forEach(address => {
         const data = dataMap.get(address);
@@ -305,10 +307,12 @@ export default function TokenTable({ data }: { data: PaginatedTokenResponse | To
         }
       });
       
-      setDexscreenerData(newDexData);
-      setLastRefreshed(new Date());
+      setDexscreenerData(newDexData)
+      setLastRefreshed(new Date())
     } catch (error) {
-      console.error("Error fetching Dexscreener data:", error);
+      console.error("Error fetching Dexscreener data:", error)
+    } finally {
+      setIsDexLoading(false)
     }
   }, [filteredTokens]);
 
@@ -527,7 +531,7 @@ export default function TokenTable({ data }: { data: PaginatedTokenResponse | To
               </tr>
             </thead>
             <tbody>
-              {isLoading ? (
+              {isLoading || isDexLoading ? (
                 <tr>
                   <td colSpan={13} className="py-8 text-center">
                     <div className="flex items-center justify-center gap-2">

--- a/components/token-table.tsx
+++ b/components/token-table.tsx
@@ -72,7 +72,6 @@ export default function TokenTable({ data }: { data: PaginatedTokenResponse | To
   const [isLoadingResearch, setIsLoadingResearch] = useState(false)
   const [dexscreenerData, setDexscreenerData] = useState<Record<string, any>>({})
   const [lastRefreshed, setLastRefreshed] = useState<Date | null>(null)
-  const [refreshCountdown, setRefreshCountdown] = useState(60)
   const searchParams = useSearchParams()
   const router = useRouter()
 
@@ -308,7 +307,6 @@ export default function TokenTable({ data }: { data: PaginatedTokenResponse | To
       
       setDexscreenerData(newDexData);
       setLastRefreshed(new Date());
-      setRefreshCountdown(60);
     } catch (error) {
       console.error("Error fetching Dexscreener data:", error);
     }
@@ -347,18 +345,7 @@ export default function TokenTable({ data }: { data: PaginatedTokenResponse | To
         : (b.marketCap || 0) - (a.marketCap || 0);
     });
 
-  useEffect(() => {
-    if (refreshCountdown <= 0) {
-      fetchDexscreenerData();
-      return;
-    }
-    
-    const timer = setTimeout(() => {
-      setRefreshCountdown(prev => prev - 1);
-    }, 1000);
-    
-    return () => clearTimeout(timer);
-  }, [refreshCountdown, fetchDexscreenerData]);
+
 
 
   // Fetch fresh Dexscreener data whenever the set of tokens changes
@@ -672,8 +659,7 @@ export default function TokenTable({ data }: { data: PaginatedTokenResponse | To
 
       <div className="flex justify-between mt-2">
         <div className="text-xs opacity-70 mt-1">
-          Last updated: {lastRefreshed ? lastRefreshed.toLocaleTimeString() : 'Never'} 
-          {lastRefreshed && <span> (refreshing in {refreshCountdown}s)</span>}
+          Last updated: {lastRefreshed ? lastRefreshed.toLocaleTimeString() : 'Never'}
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- stop re-rendering token table every second
- clean up last updated text

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684608a3f4f4832caf130f140cd6b18d