### PR TITLE
Increase Dune token fetch limit

### DIFF
--- a/app/actions/dune-actions.ts
+++ b/app/actions/dune-actions.ts
@@ -34,7 +34,7 @@ const IS_PREVIEW =
 
 const DUNE_API_KEY = process.env.DUNE_API_KEY;
 
-async function fetchDuneQueryResults(queryId: number, limit = 1000) {
+async function fetchDuneQueryResults(queryId: number, limit = 2000) {
   if (!DUNE_API_KEY) {
     console.error("DUNE_API_KEY is not set");
     return { rows: [] };


### PR DESCRIPTION
## Summary
- request more rows from Dune by default

## Testing
- `npm test`
- `npx next lint` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6846237f8ea0832c8092fedf06206ccd