### PR TITLE
Update Dune caching to 12 hours

### DIFF
--- a/app/actions/dune-actions.ts
+++ b/app/actions/dune-actions.ts
@@ -73,7 +73,7 @@ export async function fetchAllTokensFromDune(): Promise<TokenData[]> {
     if ((Date.now() - lastRefreshTime.getTime()) < CACHE_DURATION) {
       const cachedData = await getFromCache<TokenData[]>(CACHE_KEYS.ALL_TOKENS);
       if (cachedData && cachedData.length > 0) {
-        console.log("Last refresh time less than 1 hour, fetching all tokens data from cache");
+        console.log("Last refresh time less than 12 hours, fetching all tokens data from cache");
         return cachedData;
       }
     }
@@ -251,12 +251,12 @@ export async function fetchTokenMarketCaps(): Promise<TokenMarketCapData[]> {
     //     CACHE_KEYS.TOKEN_MARKET_CAPS
     //   );
     //   if (cachedData && cachedData.length > 0) {
-    //     console.log("Token market caps: Less than 1 hour since last refresh, using cache");
+    //     console.log("Token market caps: Less than 12 hours since last refresh, using cache");
     //     return cachedData;
     //   }
     // }
 
-    // console.log("Token market caps: More than 1 hour since last refresh, fetching from Dune");
+    // console.log("Token market caps: More than 12 hours since last refresh, fetching from Dune");
       const result = await fetchDuneQueryResults(5140151);
 
     if (result && result.rows && result.rows.length > 0) {
@@ -380,12 +380,12 @@ export async function fetchMarketStats(): Promise<MarketStats> {
     if ((Date.now() - lastRefreshTime.getTime()) < CACHE_DURATION) {
       const cachedData = await getFromCache<MarketStats>(CACHE_KEYS.MARKET_STATS);
       if (cachedData && cachedData.totalMarketCap !== undefined) {
-        console.log("Market stats: Less than 1 hour since last refresh, using cache");
+        console.log("Market stats: Less than 12 hours since last refresh, using cache");
         return cachedData;
       }
     }
 
-    console.log("Market stats: More than 1 hour since last refresh, fetching from Dune");
+    console.log("Market stats: More than 12 hours since last refresh, fetching from Dune");
     const result = await fetchDuneQueryResults(5140151);
 
     if (result && result.rows && result.rows.length > 0) {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -259,13 +259,13 @@ export default async function Home() {
     console.error("Error getting refresh time info:", error);
   }
 
-  const nextRefreshTime = new Date(lastRefreshTime.getTime() + 1 * 60 * 60 * 1000);
+  const nextRefreshTime = new Date(lastRefreshTime.getTime() + 12 * 60 * 60 * 1000);
   const formattedLastRefresh = lastRefreshTime.toLocaleString(undefined, {
     dateStyle: "short",
     timeStyle: "medium",
   });
   const formattedNextRefresh = nextRefreshTime.toLocaleString();
-  const hoursUntilRefresh = Math.floor(timeRemaining / (2 * 60 * 60 * 1000));
+  const hoursUntilRefresh = Math.floor(timeRemaining / (60 * 60 * 1000));
   const minutesUntilRefresh = Math.floor((timeRemaining % (60 * 60 * 1000)) / (60 * 1000));
 
   const totalMarketCapValue =

--- a/app/token/[symbol]/page.tsx
+++ b/app/token/[symbol]/page.tsx
@@ -84,7 +84,7 @@ export default function TokenPage({ params }: { params: { symbol: string } }) {
 
         setDuneLastRefresh(duneCache.lastRefreshTime);
         setDuneNextRefresh(
-          new Date(duneCache.lastRefreshTime.getTime() + 1 * 60 * 60 * 1000),
+          new Date(duneCache.lastRefreshTime.getTime() + 12 * 60 * 60 * 1000),
         );
         setDuneTimeRemaining(duneCache.timeRemaining);
 

--- a/app/tokendetail/[symbol]/page.tsx
+++ b/app/tokendetail/[symbol]/page.tsx
@@ -250,7 +250,7 @@ export default function TokenResearchPage({
 
         setDuneLastRefresh(duneCache.lastRefreshTime);
         setDuneNextRefresh(
-          new Date(duneCache.lastRefreshTime.getTime() + 1 * 60 * 60 * 1000),
+          new Date(duneCache.lastRefreshTime.getTime() + 12 * 60 * 60 * 1000),
         );
         setDuneTimeRemaining(duneCache.timeRemaining);
 

--- a/lib/redis.ts
+++ b/lib/redis.ts
@@ -20,8 +20,8 @@ export const CACHE_KEYS = {
   DEX_LOGO_PREFIX: "dexscreener:logo:",
 }
 
-export const CACHE_DURATION = 1 * 60 * 60 * 1000
-export const CACHE_DURATION_LONG = 1 * 60 * 60 * 1000
+export const CACHE_DURATION = 12 * 60 * 60 * 1000
+export const CACHE_DURATION_LONG = 12 * 60 * 60 * 1000
 export const WALLET_CACHE_DURATION = 5 * 60 * 1000
 export const DEX_LOGO_CACHE_DURATION = 60 * 60 * 1000
 


### PR DESCRIPTION
## Summary
- extend CACHE_DURATION and CACHE_DURATION_LONG constants to 12 hours
- update log messages to match the new interval
- adjust next refresh calculations on pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68463d6435f4832c8adf50dc70c2154d