### PR TITLE
Integrate Cookie.fun metrics

### DIFF
--- a/app/actions/cookie-actions.ts
+++ b/app/actions/cookie-actions.ts
@@ -1,0 +1,84 @@
+"use server";
+
+import { getFromCache, setInCache, CACHE_KEYS } from "@/lib/redis";
+
+export interface CookieMetrics {
+  mindshare: number;
+  mindshareChange?: number;
+  mentions: number;
+  smartEngagements: number;
+}
+
+const COOKIE_API_KEY = process.env.COOKIE_API_KEY;
+const COOKIE_BASE_URL = "https://api.staging.cookie.fun";
+const COOKIE_CACHE_DURATION = 60 * 60 * 1000; // 1 hour
+
+async function postCookie(path: string, body: any) {
+  if (!COOKIE_API_KEY) {
+    console.error("COOKIE_API_KEY not set");
+    return null;
+  }
+
+  try {
+    const res = await fetch(`${COOKIE_BASE_URL}${path}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": COOKIE_API_KEY,
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!res.ok) {
+      console.error(`Cookie.fun request failed: ${res.status} ${res.statusText}`);
+      return null;
+    }
+
+    return await res.json();
+  } catch (err) {
+    console.error("Cookie.fun request error", err);
+    return null;
+  }
+}
+
+export async function fetchCookieMetrics(project: string): Promise<CookieMetrics | null> {
+  if (!project) return null;
+
+  const key = `${CACHE_KEYS.COOKIE_METRICS_PREFIX}${project.toUpperCase()}`;
+  const cached = await getFromCache<CookieMetrics>(key);
+  if (cached) return cached;
+
+  const [mindshareData, metricsData] = await Promise.all([
+    postCookie("/v3/project/mindshare-graph", { project }),
+    postCookie("/v3/metrics", { project }),
+  ]);
+
+  if (!mindshareData || !metricsData) return null;
+
+  const points = mindshareData?.points || mindshareData?.data?.points || [];
+  const latest = points.length > 0 ? points[points.length - 1].value || 0 : 0;
+  const prev = points.length > 1 ? points[points.length - 2].value || 0 : 0;
+  const change = prev ? ((latest - prev) / prev) * 100 : 0;
+
+  const mentions = metricsData?.mentions24h ?? metricsData?.mentions ?? 0;
+  const smartEngagements = metricsData?.smartEngagements24h ?? metricsData?.smartEngagements ?? 0;
+
+  const result: CookieMetrics = {
+    mindshare: latest,
+    mindshareChange: change,
+    mentions,
+    smartEngagements,
+  };
+
+  await setInCache(key, result, COOKIE_CACHE_DURATION);
+  return result;
+}
+
+export async function batchFetchCookieMetrics(projects: string[]): Promise<Map<string, CookieMetrics | null>> {
+  const result = new Map<string, CookieMetrics | null>();
+  for (const proj of projects) {
+    const data = await fetchCookieMetrics(proj);
+    result.set(proj, data);
+  }
+  return result;
+}

--- a/app/actions/cookie-actions.ts
+++ b/app/actions/cookie-actions.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { getFromCache, setInCache, CACHE_KEYS } from "@/lib/redis";
+import { getTokenSlug } from "@/data/token-slug-map";
 
 export interface CookieMetrics {
   mindshare: number;
@@ -79,6 +80,39 @@ export async function batchFetchCookieMetrics(projects: string[]): Promise<Map<s
   for (const proj of projects) {
     const data = await fetchCookieMetrics(proj);
     result.set(proj, data);
+  }
+  return result;
+}
+
+export async function fetchProjectSlug(symbol: string, address?: string): Promise<string | null> {
+  const direct = getTokenSlug(symbol);
+  if (direct) return direct;
+  if (!address) return null;
+  const key = `${CACHE_KEYS.COOKIE_SLUG_PREFIX}${address.toLowerCase()}`;
+  const cached = await getFromCache<string>(key);
+  if (cached) return cached;
+
+  const data = await postCookie("/v3/project/search", { contractAddress: address });
+  const slug = data?.slug || data?.project?.slug || data?.data?.slug;
+  if (slug) {
+    await setInCache(key, slug, COOKIE_CACHE_DURATION);
+    return slug as string;
+  }
+  return null;
+}
+
+export interface TokenIdentifier {
+  symbol: string;
+  token?: string;
+}
+
+export async function batchFetchCookieMetricsForTokens(tokens: TokenIdentifier[]): Promise<Map<string, CookieMetrics | null>> {
+  const result = new Map<string, CookieMetrics | null>();
+  for (const t of tokens) {
+    const slug = await fetchProjectSlug(t.symbol, t.token);
+    if (!slug) continue;
+    const data = await fetchCookieMetrics(slug);
+    result.set(t.symbol.toUpperCase(), data);
   }
   return result;
 }

--- a/components/token-search-list.tsx
+++ b/components/token-search-list.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/app/actions/googlesheet-action";
 import { batchFetchTokensData } from "@/app/actions/dexscreener-actions";
 import { batchFetchCookieMetrics, type CookieMetrics } from "@/app/actions/cookie-actions";
+import { getTokenSlug } from "@/data/token-slug-map";
 import { TokenCard } from "./token-card";
 import { 
   Loader2, 
@@ -101,13 +102,16 @@ export default function TokenSearchList() {
 
   const fetchCookieData = useCallback(async (tokenList: TokenData[]) => {
     const symbols = tokenList.map(t => t.symbol).filter(Boolean);
-    if (!symbols.length) return;
+    const slugs = symbols.map(sym => getTokenSlug(sym)).filter(Boolean) as string[];
+    if (!slugs.length) return;
     try {
-      const map = await batchFetchCookieMetrics(symbols);
+      const map = await batchFetchCookieMetrics(slugs);
       setCookieMetrics(prev => {
         const updated: Record<string, CookieMetrics> = { ...prev };
         symbols.forEach(sym => {
-          const data = map.get(sym);
+          const slug = getTokenSlug(sym);
+          if (!slug) return;
+          const data = map.get(slug);
           if (data) {
             updated[sym.toUpperCase()] = data;
           }

--- a/components/token-table.tsx
+++ b/components/token-table.tsx
@@ -332,7 +332,7 @@ export default function TokenTable({ data }: { data: PaginatedTokenResponse | To
       symbols.forEach(sym => {
         const data = dataMap.get(sym);
         if (data) {
-          newCookieData[sym] = data;
+          newCookieData[sym.toUpperCase()] = data;
         }
       });
 

--- a/components/token-table.tsx
+++ b/components/token-table.tsx
@@ -33,6 +33,7 @@ import { CopyAddress } from "@/components/copy-address"
 import { batchFetchTokensData } from "@/app/actions/dexscreener-actions"
 import { fetchTokenResearch } from "@/app/actions/googlesheet-action"
 import { batchFetchCookieMetrics, type CookieMetrics } from "@/app/actions/cookie-actions"
+import { getTokenSlug } from "@/data/token-slug-map"
 import { canonicalChecklist } from "@/components/founders-edge-checklist"
 import { gradeMaps, valueToScore } from "@/lib/score"
 import { researchFilterOptions } from "@/data/research-filter-options"
@@ -323,14 +324,18 @@ export default function TokenTable({ data }: { data: PaginatedTokenResponse | To
       .map(token => token.symbol)
       .filter(sym => sym && typeof sym === "string");
 
-    if (symbols.length === 0) return;
+    const slugs = symbols.map(sym => getTokenSlug(sym)).filter(Boolean) as string[];
+
+    if (slugs.length === 0) return;
 
     try {
-      const dataMap = await batchFetchCookieMetrics(symbols);
+      const dataMap = await batchFetchCookieMetrics(slugs);
       const newCookieData: Record<string, CookieMetrics> = {};
 
       symbols.forEach(sym => {
-        const data = dataMap.get(sym);
+        const slug = getTokenSlug(sym);
+        if (!slug) return;
+        const data = dataMap.get(slug);
         if (data) {
           newCookieData[sym.toUpperCase()] = data;
         }

--- a/data/token-slug-map.ts
+++ b/data/token-slug-map.ts
@@ -1,0 +1,14 @@
+export const tokenSlugMap: Record<string, string> = {
+  KLED: "kled",
+  DUPE: "dupe",
+  PCULE: "pcule",
+  GOONC: "goonc",
+  FITCOIN: "fitcoin",
+  STARTUP: "startup",
+  YAPPER: "yapper",
+  // add more as needed
+};
+
+export function getTokenSlug(symbol: string): string | undefined {
+  return tokenSlugMap[(symbol || '').toUpperCase()];
+}

--- a/lib/redis.ts
+++ b/lib/redis.ts
@@ -19,6 +19,7 @@ export const CACHE_KEYS = {
   CREATOR_WALLETS_LAST_REFRESH: "dashcoin:creator_wallets_last_refresh",
   DEX_LOGO_PREFIX: "dexscreener:logo:",
   COOKIE_METRICS_PREFIX: "cookie:metrics:",
+  COOKIE_SLUG_PREFIX: "cookie:slug:",
 }
 
 export const CACHE_DURATION = 1 * 60 * 60 * 1000

--- a/lib/redis.ts
+++ b/lib/redis.ts
@@ -18,6 +18,7 @@ export const CACHE_KEYS = {
   CREATOR_WALLETS: "dashcoin:creator_wallets",
   CREATOR_WALLETS_LAST_REFRESH: "dashcoin:creator_wallets_last_refresh",
   DEX_LOGO_PREFIX: "dexscreener:logo:",
+  COOKIE_METRICS_PREFIX: "cookie:metrics:",
 }
 
 export const CACHE_DURATION = 1 * 60 * 60 * 1000


### PR DESCRIPTION
## Summary
- add Cookie.fun API helper with Redis caching
- track Cookie fun metrics in Redis keys
- load mindshare and metrics in token table
- show mindshare column and social metric icons

## Testing
- `npm test`
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68473b510a30832cbaab271efb537f53