### PR TITLE
Add Cookie.fun metrics table

### DIFF
--- a/app/api/cookie-data/route.ts
+++ b/app/api/cookie-data/route.ts
@@ -1,0 +1,103 @@
+import { NextResponse } from 'next/server'
+
+const COOKIE_API_KEY = process.env.COOKIE_API_KEY || ''
+const API_BASE = 'https://api.staging.cookie.fun'
+
+interface MetricEntry {
+  date: string
+  value: number
+}
+
+interface TokenResult {
+  token: string
+  mindshare: number | null
+  mentions: number | null
+  smartEngagements: number | null
+  updated: string | null
+  error?: string
+}
+
+const TOKENS = ['dupe', 'kled', 'yapper']
+const CACHE_TTL = 60 * 60 * 1000
+
+const cache = new Map<string, { data: TokenResult; timestamp: number }>()
+
+async function fetchMindshare(slug: string): Promise<MetricEntry> {
+  const res = await fetch(`${API_BASE}/v3/project/mindshare-graph`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': COOKIE_API_KEY,
+    },
+    body: JSON.stringify({ projectSlug: slug, granulation: '_24Hours' }),
+  })
+  const json = await res.json()
+  if (!res.ok || !json.success) {
+    throw new Error(json.error?.message || 'Failed to fetch mindshare')
+  }
+  const entries = json.ok?.entries || []
+  return entries[entries.length - 1] || { date: new Date().toISOString(), value: 0 }
+}
+
+async function fetchMetric(slug: string, metric: string): Promise<MetricEntry> {
+  const res = await fetch(`${API_BASE}/v3/metrics`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': COOKIE_API_KEY,
+    },
+    body: JSON.stringify({
+      projectSlug: slug,
+      metricType: metric,
+      granulation: '_24Hours',
+    }),
+  })
+  const json = await res.json()
+  if (!res.ok || !json.success) {
+    throw new Error(json.error?.message || `Failed to fetch ${metric}`)
+  }
+  const entries = json.ok?.entries || []
+  return entries[entries.length - 1] || { date: new Date().toISOString(), value: 0 }
+}
+
+export async function GET(req: Request) {
+  const force = req.url.includes('refresh=1')
+  const results: TokenResult[] = []
+  const now = Date.now()
+
+  for (const slug of TOKENS) {
+    const cached = cache.get(slug)
+    if (cached && !force && now - cached.timestamp < CACHE_TTL) {
+      results.push(cached.data)
+      continue
+    }
+
+    let tokenData: TokenResult = {
+      token: slug.toUpperCase(),
+      mindshare: null,
+      mentions: null,
+      smartEngagements: null,
+      updated: null,
+    }
+
+    try {
+      const [mind, mentions, smart] = await Promise.all([
+        fetchMindshare(slug),
+        fetchMetric(slug, 'Mentions'),
+        fetchMetric(slug, 'SmartEngagements'),
+      ])
+      tokenData.mindshare = mind.value
+      tokenData.mentions = mentions.value
+      tokenData.smartEngagements = smart.value
+      tokenData.updated = mind.date || new Date().toISOString()
+    } catch (err: any) {
+      tokenData.error = err.message || 'API error'
+    }
+
+    cache.set(slug, { data: tokenData, timestamp: now })
+    results.push(tokenData)
+  }
+
+  return NextResponse.json({ data: results })
+}
+

--- a/app/cookie/page.tsx
+++ b/app/cookie/page.tsx
@@ -1,0 +1,14 @@
+import { Navbar } from '@/components/navbar'
+import { CookieTable } from '@/components/cookie-table'
+
+export default function CookiePage() {
+  return (
+    <div className="min-h-screen bg-slate-950 text-white">
+      <Navbar />
+      <main className="container mx-auto px-4 py-12 max-w-4xl">
+        <CookieTable />
+      </main>
+    </div>
+  )
+}
+

--- a/components/cookie-table.tsx
+++ b/components/cookie-table.tsx
@@ -1,0 +1,106 @@
+"use client"
+
+import { useEffect, useState } from 'react'
+import { DashcoinCard, DashcoinCardHeader, DashcoinCardTitle, DashcoinCardContent } from '@/components/ui/dashcoin-card'
+
+interface TokenRow {
+  token: string
+  mindshare: number | null
+  mentions: number | null
+  smartEngagements: number | null
+  updated: string | null
+  error?: string
+}
+
+export function CookieTable() {
+  const [data, setData] = useState<TokenRow[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const loadData = async (force = false) => {
+    try {
+      setLoading(true)
+      const res = await fetch(`/api/cookie-data${force ? '?refresh=1' : ''}`)
+      const json = await res.json()
+      setData(json.data || [])
+    } catch (err) {
+      console.error('Failed to load cookie data', err)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    loadData()
+    const id = setInterval(() => loadData(), 60 * 60 * 1000)
+    return () => clearInterval(id)
+  }, [])
+
+  const formatTime = (iso: string | null) => {
+    if (!iso) return '—'
+    const d = new Date(iso)
+    return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+  }
+
+  const isStale = (iso: string | null) => {
+    if (!iso) return false
+    return Date.now() - new Date(iso).getTime() > 2 * 60 * 60 * 1000
+  }
+
+  return (
+    <DashcoinCard>
+      <DashcoinCardHeader>
+        <DashcoinCardTitle>Cookie.fun Metrics</DashcoinCardTitle>
+      </DashcoinCardHeader>
+      <DashcoinCardContent>
+        <div className="mb-4">
+          <button onClick={() => loadData(true)} className="px-3 py-1 bg-dashGreen text-white rounded-md text-sm">Refresh Now</button>
+        </div>
+        <div className="overflow-x-auto">
+          <table className="w-full border-collapse">
+            <thead>
+              <tr className="bg-dashBlue-dark border-b border-dashBlack">
+                <th className="text-left py-2 px-4 text-dashYellow">Token</th>
+                <th className="text-left py-2 px-4 text-dashYellow">Mindshare</th>
+                <th className="text-left py-2 px-4 text-dashYellow">Mentions</th>
+                <th className="text-left py-2 px-4 text-dashYellow">SmartEngagements</th>
+                <th className="text-left py-2 px-4 text-dashYellow">Last Updated</th>
+                <th className="text-left py-2 px-4 text-dashYellow">Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {loading ? (
+                <tr>
+                  <td colSpan={6} className="py-6 text-center">Loading...</td>
+                </tr>
+              ) : data.length > 0 ? (
+                data.map(row => (
+                  <tr key={row.token} className="border-b border-dashBlue-light">
+                    <td className="py-2 px-4 font-semibold">{row.token}</td>
+                    <td className="py-2 px-4">{row.mindshare ?? '—'}</td>
+                    <td className="py-2 px-4">{row.mentions ?? '—'}</td>
+                    <td className="py-2 px-4">{row.smartEngagements ?? '—'}</td>
+                    <td className="py-2 px-4">{formatTime(row.updated)}</td>
+                    <td className="py-2 px-4">
+                      {row.error ? (
+                        <span title={row.error}>❌ API error</span>
+                      ) : isStale(row.updated) ? (
+                        <span title="Stale data">⚠️</span>
+                      ) : (
+                        '✅ OK'
+                      )}
+                    </td>
+                  </tr>
+                ))
+              ) : (
+                <tr>
+                  <td colSpan={6} className="py-6 text-center">No data</td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      </DashcoinCardContent>
+    </DashcoinCard>
+  )
+}
+

--- a/components/cookie-table.tsx
+++ b/components/cookie-table.tsx
@@ -5,6 +5,7 @@ import { DashcoinCard, DashcoinCardHeader, DashcoinCardTitle, DashcoinCardConten
 
 interface TokenRow {
   token: string
+  address: string
   mindshare: number | null
   mentions: number | null
   smartEngagements: number | null

--- a/components/token-search-list.tsx
+++ b/components/token-search-list.tsx
@@ -151,7 +151,8 @@ export default function TokenSearchList() {
         const json = await res.json();
         const map: Record<string, { mindshare: number | null; mentions: number | null; smartEngagements: number | null; updated: string | null }> = {};
         (json.data || []).forEach((row: any) => {
-          const key = (row.token || '').toUpperCase();
+          const key = (row.address || '').toLowerCase();
+          if (!key) return;
           map[key] = {
             mindshare: row.mindshare ?? null,
             mentions: row.mentions ?? null,
@@ -174,7 +175,7 @@ export default function TokenSearchList() {
         researchScores.find(r => r.symbol.toUpperCase() === sym) || {};
       const dex = dexscreenerData[t.token] || {};
       const wallet = walletInfo[sym] || { walletLink: '', twitter: '' };
-      const cookie = cookieMetrics[sym] || {};
+      const cookie = cookieMetrics[t.token.toLowerCase()] || {};
       return {
         ...t,
         ...dex,


### PR DESCRIPTION
## Summary
- add API route for Cookie.fun metrics with caching and error handling
- create CookieTable component displaying results with refresh button
- new `/cookie` page to show table

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68475bbddf54832c8501e6fbb37c56e5