### PR TITLE
Reorder homepage sections

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -351,48 +351,8 @@ export default async function Home() {
             </div>
           </div>
 
-          {/* Quick Stats Grid - Improved Layout */}
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 items-stretch">
-            <QuickStatsCard
-              icon={TrendingUp}
-              title="Total Market Cap"
-              value={formattedTotalMarketCap}
-              change="+12.5%"
-              changeType="positive"
-            />
-            <QuickStatsCard
-              icon={Activity}
-              title="Total Volume"
-              value={formattedVolume}
-              change="+8.2%"
-              changeType="positive"
-            />
-            <QuickStatsCard
-              icon={DollarSign}
-              title="Creator Fees"
-              value={formattedFeeEarnings0}
-              change="+15.7%"
-              changeType="positive"
-              subtitle="Estimated from total volume*"
-            />
-            <QuickStatsCard
-              icon={Users}
-              title="Indexed Tokens"
-              value={marketStats?.coinLaunches || "N/A"}
-              change="+3"
-              changeType="positive"
-            />
-          </div>
         </section>
 
-        {/* Trade Dashcoin Section */}
-        <section className="mb-12 flex justify-center">
-          <DashcStatsBar
-            tradeLink={dashcoinTradeLink}
-            marketCap={dashcMarketCap}
-            contractAddress={dashcoinCA}
-          />
-        </section>
 
 
         {/* Token Analysis Section */}
@@ -434,6 +394,50 @@ export default async function Home() {
               <TokenSearchListWrapper />
             </div>
         </Suspense>
+      </section>
+
+      {/* Quick Stats Grid - Metrics */}
+      <section className="mb-12">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 items-stretch">
+          <QuickStatsCard
+            icon={TrendingUp}
+            title="Total Market Cap"
+            value={formattedTotalMarketCap}
+            change="+12.5%"
+            changeType="positive"
+          />
+          <QuickStatsCard
+            icon={Activity}
+            title="Total Volume"
+            value={formattedVolume}
+            change="+8.2%"
+            changeType="positive"
+          />
+          <QuickStatsCard
+            icon={DollarSign}
+            title="Creator Fees"
+            value={formattedFeeEarnings0}
+            change="+15.7%"
+            changeType="positive"
+            subtitle="Estimated from total volume*"
+          />
+          <QuickStatsCard
+            icon={Users}
+            title="Indexed Tokens"
+            value={marketStats?.coinLaunches || "N/A"}
+            change="+3"
+            changeType="positive"
+          />
+        </div>
+      </section>
+
+      {/* Trade Dashcoin Section */}
+      <section className="mb-12 flex justify-center">
+        <DashcStatsBar
+          tradeLink={dashcoinTradeLink}
+          marketCap={dashcMarketCap}
+          contractAddress={dashcoinCA}
+        />
       </section>
 
       {/* Market Overview Section */}


### PR DESCRIPTION
## Summary
- move token analysis section directly under the hero
- show metrics grid after the token directory
- move trade bar below metrics

## Testing
- `npm test`
- `npx next lint` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684b26394928832c9989775117557420