### PR TITLE
Add Cookie.fun search links

### DIFF
--- a/components/token-search-list.tsx
+++ b/components/token-search-list.tsx
@@ -42,6 +42,9 @@ import { canonicalChecklist } from "@/components/founders-edge-checklist";
 import { gradeMaps, valueToScore } from "@/lib/score";
 import Link from "next/link";
 
+const toSlug = (name: string = "") =>
+  name.toLowerCase().replace(/\s+/g, "-");
+
 interface ResearchScoreData {
   symbol: string;
   score: number | null;
@@ -460,6 +463,12 @@ export default function TokenSearchList() {
                       Research
                     </div>
                   </th>
+                  <th className="text-left py-4 px-6 text-slate-300 font-medium whitespace-nowrap">
+                    <div className="flex items-center gap-2">
+                      <Search className="w-4 h-4" />
+                      Search on Cookie.fun
+                    </div>
+                  </th>
                   <th className="text-left py-4 px-6 text-slate-300 font-medium">Links</th>
                 </tr>
               </thead>
@@ -534,6 +543,17 @@ export default function TokenSearchList() {
                       ) : (
                         <span className="text-slate-500">-</span>
                       )}
+                    </td>
+                    <td className="py-4 px-6">
+                      <a
+                        href={`https://www.cookie.fun/tokens/${toSlug(token.name || token.symbol)}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="p-2 bg-white/5 hover:bg-white/10 border border-white/10 rounded-lg transition-colors group/btn"
+                        title="Search on Cookie.fun"
+                      >
+                        <ExternalLink className="w-4 h-4 text-slate-400 group-hover/btn:text-teal-400" />
+                      </a>
                     </td>
                     <td className="py-4 px-6">
                       <div className="flex items-center gap-2">

--- a/components/token-search-list.tsx
+++ b/components/token-search-list.tsx
@@ -24,6 +24,7 @@ import {
   Star,
   ExternalLink,
   Twitter,
+  Cookie,
   Wallet,
   Activity,
   DollarSign,
@@ -463,12 +464,6 @@ export default function TokenSearchList() {
                       Research
                     </div>
                   </th>
-                  <th className="text-left py-4 px-6 text-slate-300 font-medium whitespace-nowrap">
-                    <div className="flex items-center gap-2">
-                      <Search className="w-4 h-4" />
-                      Search on Cookie.fun
-                    </div>
-                  </th>
                   <th className="text-left py-4 px-6 text-slate-300 font-medium">Links</th>
                 </tr>
               </thead>
@@ -545,17 +540,6 @@ export default function TokenSearchList() {
                       )}
                     </td>
                     <td className="py-4 px-6">
-                      <a
-                        href={`https://www.cookie.fun/tokens/${toSlug(token.name || token.symbol)}`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="p-2 bg-white/5 hover:bg-white/10 border border-white/10 rounded-lg transition-colors group/btn"
-                        title="Search on Cookie.fun"
-                      >
-                        <ExternalLink className="w-4 h-4 text-slate-400 group-hover/btn:text-teal-400" />
-                      </a>
-                    </td>
-                    <td className="py-4 px-6">
                       <div className="flex items-center gap-2">
                         {token.token && (
                           <a
@@ -591,6 +575,15 @@ export default function TokenSearchList() {
                             <Twitter className="w-4 h-4 text-slate-400 group-hover/btn:text-teal-400" />
                           </a>
                         )}
+                        <a
+                          href={`https://www.cookie.fun/tokens/${toSlug(token.name || token.symbol)}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="p-2 bg-white/5 hover:bg-white/10 border border-white/10 rounded-lg transition-colors group/btn"
+                          title="View on Cookie.fun"
+                        >
+                          <Cookie className="w-4 h-4 text-slate-400 group-hover/btn:text-teal-400" />
+                        </a>
                       </div>
                     </td>
                   </tr>


### PR DESCRIPTION
## Summary
- add utility to create slugs
- add `Search on Cookie.fun` column to token table
- link each row to Cookie.fun token page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b2cbeaf9c832c9815f137e44e9fbc