### PR TITLE
Add Bull Case section driven by Google Sheet

### DIFF
--- a/app/actions/googlesheet-action.ts
+++ b/app/actions/googlesheet-action.ts
@@ -10,6 +10,7 @@ import {
 interface ResearchScoreData {
   symbol: string
   score: number | null
+  "Bull Case"?: string
   [key: string]: any
 }
 
@@ -73,6 +74,7 @@ export async function fetchTokenResearch(): Promise<ResearchScoreData[]> {
         'Funding Status',
         'Token-Product Integration Depth',
         'Social Reach & Engagement Index',
+        'Bull Case',
       ].forEach(label => {
         result[label] = entry[label] ?? '';
       });

--- a/app/tokendetail/[symbol]/page.tsx
+++ b/app/tokendetail/[symbol]/page.tsx
@@ -66,6 +66,7 @@ interface TokenResearchData {
   Comments: string;
   "Wallet Link": string;
   "Wallet Comments": string;
+  "Bull Case"?: string;
   Twitter?: string;
   [key: string]: any;
 }
@@ -459,6 +460,23 @@ export default function TokenResearchPage({
             
             <div className="bg-white/5 backdrop-blur-xl border border-white/10 rounded-2xl p-8">
               <FoundersEdgeChecklist data={researchData} showLegend />
+            </div>
+          </section>
+        )}
+
+        {/* Bull Case */}
+        {researchData?.["Bull Case"] && (
+          <section className="mb-12">
+            <div className="flex items-center gap-4 mb-4">
+              <div className="p-3 bg-gradient-to-r from-emerald-500 to-teal-500 rounded-xl">
+                <ArrowUp className="w-6 h-6 text-white" />
+              </div>
+              <h2 className="text-3xl font-bold text-white">Bull Case</h2>
+            </div>
+            <div className="bg-white/5 backdrop-blur-xl border border-white/10 rounded-2xl p-8">
+              <p className="text-slate-300 whitespace-pre-line">
+                {researchData["Bull Case"]}
+              </p>
             </div>
           </section>
         )}


### PR DESCRIPTION
## Summary
- include `Bull Case` field when loading research data from Google Sheets
- render Bull Case section on token detail pages

## Testing
- `npm test`
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684bc4ad88d0832c8c756281d8dd222f