### PR TITLE
Add LinkedIn link support

### DIFF
--- a/app/actions/googlesheet-action.ts
+++ b/app/actions/googlesheet-action.ts
@@ -91,6 +91,7 @@ interface WalletLinkData {
   walletLink: string
   walletActivity: string
   twitter: string
+  linkedin: string
 }
 
 export async function fetchCreatorWalletLinks(): Promise<WalletLinkData[]> {
@@ -129,7 +130,8 @@ export async function fetchCreatorWalletLinks(): Promise<WalletLinkData[]> {
         symbol: (entry['Project'] || '').toString().toUpperCase(),
         walletLink: entry['Wallet Link'] || '',
         walletActivity: entry['Wallet Comments'] || '',
-        twitter: entry['Twitter'] || ''
+        twitter: entry['Twitter'] || '',
+        linkedin: entry['LinkedIn'] || ''
       }
     })
     await setInCache(CACHE_KEYS.CREATOR_WALLETS, result, WALLET_CACHE_DURATION)

--- a/components/token-search-list.tsx
+++ b/components/token-search-list.tsx
@@ -24,6 +24,7 @@ import {
   Star,
   ExternalLink,
   Twitter,
+  Linkedin,
   Cookie,
   Wallet,
   Activity,
@@ -64,7 +65,7 @@ export default function TokenSearchList() {
   const [loading, setLoading] = useState(true);
   const [researchScores, setResearchScores] = useState<ResearchScoreData[]>([]);
   const [dexscreenerData, setDexscreenerData] = useState<Record<string, any>>({});
-  const [walletInfo, setWalletInfo] = useState<Record<string, { walletLink: string; twitter: string }>>({});
+  const [walletInfo, setWalletInfo] = useState<Record<string, { walletLink: string; twitter: string; linkedin: string }>>({});
   const [viewMode, setViewMode] = useState<'card' | 'table'>('table');
   const [searchTerm, setSearchTerm] = useState("");
   const [pageSize, setPageSize] = useState(12);
@@ -132,11 +133,12 @@ export default function TokenSearchList() {
     const loadWallets = async () => {
       try {
         const data = await fetchCreatorWalletLinks();
-        const map: Record<string, { walletLink: string; twitter: string }> = {};
+        const map: Record<string, { walletLink: string; twitter: string; linkedin: string }> = {};
         data.forEach(d => {
           map[d.symbol.toUpperCase()] = {
             walletLink: d.walletLink,
             twitter: d.twitter,
+            linkedin: d.linkedin,
           };
         });
         setWalletInfo(map);
@@ -153,7 +155,7 @@ export default function TokenSearchList() {
       const research =
         researchScores.find(r => r.symbol.toUpperCase() === sym) || {};
       const dex = dexscreenerData[t.token] || {};
-      const wallet = walletInfo[sym] || { walletLink: '', twitter: '' };
+      const wallet = walletInfo[sym] || { walletLink: '', twitter: '', linkedin: '' };
       return {
         ...t,
         ...dex,
@@ -573,6 +575,17 @@ export default function TokenSearchList() {
                             title="Twitter"
                           >
                             <Twitter className="w-4 h-4 text-slate-400 group-hover/btn:text-teal-400" />
+                          </a>
+                        )}
+                        {token.linkedin && (
+                          <a
+                            href={token.linkedin}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="p-2 bg-white/5 hover:bg-white/10 border border-white/10 rounded-lg transition-colors group/btn"
+                            title="LinkedIn"
+                          >
+                            <Linkedin className="w-4 h-4 text-slate-400 group-hover/btn:text-teal-400" />
                           </a>
                         )}
                         <a


### PR DESCRIPTION
## Summary
- fetch LinkedIn URLs from Google Sheets
- track LinkedIn links in token search state
- display LinkedIn icon button in the token table

## Testing
- `npm test`
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e0e777b14832cb5aaf5403c2fa0fe