### PR TITLE
Add LinkedIn icon to token table

### DIFF
--- a/components/token-search-list.tsx
+++ b/components/token-search-list.tsx
@@ -24,6 +24,7 @@ import {
   Star,
   ExternalLink,
   Twitter,
+  Linkedin,
   Cookie,
   Wallet,
   Activity,
@@ -573,6 +574,17 @@ export default function TokenSearchList() {
                             title="Twitter"
                           >
                             <Twitter className="w-4 h-4 text-slate-400 group-hover/btn:text-teal-400" />
+                          </a>
+                        )}
+                        {token.linkedin && (
+                          <a
+                            href={token.linkedin}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="p-2 bg-white/5 hover:bg-white/10 border border-white/10 rounded-lg transition-colors group/btn"
+                            title="LinkedIn"
+                          >
+                            <Linkedin className="w-4 h-4 text-slate-400 group-hover/btn:text-teal-400" />
                           </a>
                         )}
                         <a


### PR DESCRIPTION
## Summary
- include `Linkedin` icon in token-search-list
- add LinkedIn action link in token table

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684e2a094c4c832ca66f56ae37a34316