### PR TITLE
Remove Guide tab from navbar

### DIFF
--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -37,7 +37,6 @@ export function Navbar() {
     { href: "/compare", label: "Compare", icon: GitCompare },
     { href: "/creator-wallets", label: "Wallets", icon: Wallet },
     { href: "/founder-interviews", label: "Interviews", icon: MessageCircle },
-    { href: "https://dashcoin-research.gitbook.io/dashcoin-research", label: "Guide", icon: BookOpen, external: true },
     { href: "https://dashcoin-research-tg-gated.vercel.app/", label: "Dashcoin Holder Alpha Group", icon: Users, external: true, highlight: true }
   ];
 


### PR DESCRIPTION
## Summary
- delete the Guide link from `Navbar`

## Testing
- `npm test`
- `npm run lint` *(fails: `next` not found)*
- `./setup.sh` *(fails to install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684f8bdf63e4832c804871f0e86084f2