### PR TITLE
Enable hyperlinks in Bull Case

### DIFF
--- a/app/tokendetail/[symbol]/page.tsx
+++ b/app/tokendetail/[symbol]/page.tsx
@@ -46,7 +46,7 @@ import {
   getTimeUntilNextDexscreenerRefresh,
 } from "@/app/actions/dexscreener-actions";
 import { fetchDexscreenerTokenLogo } from "@/app/actions/dexscreener-actions";
-import { formatCurrency } from "@/lib/utils";
+import { formatCurrency, linkify } from "@/lib/utils";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { CopyAddress } from "@/components/copy-address";
@@ -478,9 +478,12 @@ export default function TokenResearchPage({
               <h2 className="text-3xl font-bold text-white">Bull Case</h2>
             </div>
             <div className="bg-white/5 backdrop-blur-xl border border-white/10 rounded-2xl p-8">
-              <p className="text-slate-300 whitespace-pre-line">
-                {researchData["Bull Case"]}
-              </p>
+              <p
+                className="text-slate-300 whitespace-pre-line"
+                dangerouslySetInnerHTML={{
+                  __html: linkify(researchData["Bull Case"] as string),
+                }}
+              />
             </div>
           </section>
         )}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -108,3 +108,13 @@ export function hexToRgba(hex: string, alpha: number): string {
   const b = bigint & 255
   return `rgba(${r}, ${g}, ${b}, ${alpha})`
 }
+
+export function linkify(text: string): string {
+  if (!text) return ''
+  const markdownLink = /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g
+  const url = /(https?:\/\/[^\s]+)/g
+  return text
+    .replace(markdownLink, '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>')
+    .replace(url, '<a href="$1" target="_blank" rel="noopener noreferrer">$1</a>')
+    .replace(/\n/g, '<br />')
+}


### PR DESCRIPTION
## Summary
- add `linkify` helper to convert URLs and markdown links to anchors
- render Bull Case text using `dangerouslySetInnerHTML` with `linkify`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684fac0ff1c8832cb578a7ebdb333389