### PR TITLE
Update token detail metrics

### DIFF
--- a/app/tokendetail/[symbol]/page.tsx
+++ b/app/tokendetail/[symbol]/page.tsx
@@ -46,7 +46,7 @@ import {
   getTimeUntilNextDexscreenerRefresh,
 } from "@/app/actions/dexscreener-actions";
 import { fetchDexscreenerTokenLogo } from "@/app/actions/dexscreener-actions";
-import { formatCurrency } from "@/lib/utils";
+import { formatCurrency, formatCurrency0 } from "@/lib/utils";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { CopyAddress } from "@/components/copy-address";
@@ -328,6 +328,8 @@ export default function TokenResearchPage({
   const price = dexscreenerData?.priceUsd
     ? Number.parseFloat(dexscreenerData.priceUsd)
     : (tokenData && tokenData.price) || 0;
+  const marketCap =
+    dexscreenerData?.fdv || (tokenData && tokenData.marketCap) || 0;
   const change24h =
     dexscreenerData?.priceChange?.h24 ||
     (tokenData && tokenData.change24h) ||
@@ -519,8 +521,8 @@ export default function TokenResearchPage({
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 mb-8">
                 <StatsCard
                   icon={DollarSign}
-                  title="Current Price"
-                  value={`$${price.toFixed(6)}`}
+                  title="Current Marketcap"
+                  value={formatCurrency0(marketCap)}
                   change={`${change24h >= 0 ? '+' : ''}${change24h.toFixed(2)}%`}
                   changeType={change24h >= 0 ? 'positive' : 'negative'}
                   subtitle="24h change"
@@ -530,7 +532,7 @@ export default function TokenResearchPage({
                 <StatsCard
                   icon={Activity}
                   title="24h Volume"
-                  value={formatCurrency(volume24h)}
+                  value={formatCurrency0(volume24h)}
                   change={`${change1h >= 0 ? '+' : ''}${change1h.toFixed(2)}%`}
                   changeType={change1h >= 0 ? 'positive' : 'negative'}
                   subtitle="1h change"
@@ -540,7 +542,7 @@ export default function TokenResearchPage({
                 <StatsCard
                   icon={Users}
                   title="Liquidity"
-                  value={formatCurrency(liquidity)}
+                  value={formatCurrency0(liquidity)}
                   subtitle="Available liquidity"
                   gradient="bg-gradient-to-r from-green-500/20 to-teal-500/20"
                 />
@@ -638,23 +640,7 @@ export default function TokenResearchPage({
                         <span className="text-sm text-white font-medium">{createdTime}</span>
                       </div>
 
-                      {dexscreenerData?.dexId && (
-                        <div className="flex justify-between">
-                          <span className="text-sm text-slate-400">DEX</span>
-                          <span className="text-sm text-white font-medium">{dexscreenerData.dexId}</span>
-                        </div>
-                      )}
 
-                      {dexscreenerData?.pairAddress && (
-                        <div className="flex justify-between items-center">
-                          <span className="text-sm text-slate-400">Pair Address</span>
-                          <CopyAddress
-                            address={dexscreenerData.pairAddress}
-                            showBackground={true}
-                            className="text-teal-400 hover:text-teal-300"
-                          />
-                        </div>
-                      )}
                     </div>
                   </div>
                 </div>

--- a/components/founders-edge-checklist.tsx
+++ b/components/founders-edge-checklist.tsx
@@ -19,52 +19,52 @@ export interface TraitInfo {
 export const canonicalChecklist: TraitInfo[] = [
   {
     label: "Team Doxxed",
-    display: "Team Doxxed",
+    display: "Is the team publicly doxxed and verifiable?",
     category: "Team",
     description:
       "This team has disclosed legal names. This boosts trust in volatile markets.",
   },
   {
     label: "Twitter Activity Level",
-    display: "Twitter Activity Level",
+    display: "How active and consistent is the team on Twitter?",
     category: "Community",
     description: "How frequently the team engages on Twitter and shares updates.",
   },
   {
     label: "Time Commitment",
-    display: "Time Commitment",
+    display: "Is the team working on this full-time or part-time?",
     category: "Team",
     description:
       "Indicates if the founders are working full time or part time on the project.",
   },
   {
     label: "Prior Founder Experience",
-    display: "Prior Founder Experience",
+    display: "Do the founders have prior experience building or scaling projects?",
     category: "Team",
     description: "Number of past startups founded by the team members.",
   },
   {
     label: "Product Maturity",
-    display: "Product Maturity",
+    display: "How far along is the product in terms of development and user adoption?",
     category: "Product",
     description:
       "Stage of the product: prototype, MVP, or revenue generating.",
   },
   {
     label: "Funding Status",
-    display: "Funding Status",
+    display: "Has the project raised any funding?",
     category: "Funding",
     description: "Whether the project is venture backed, angel funded or bootstrapped.",
   },
   {
     label: "Token-Product Integration Depth",
-    display: "Token-Product Integration Depth",
+    display: "How deeply is the token integrated into the core functionality of the product?",
     category: "Product",
     description: "How integrated the token is within the live product.",
   },
   {
     label: "Social Reach & Engagement Index",
-    display: "Social Reach",
+    display: "How large is the project's social following?",
     category: "Community",
     description: "Overall social following and engagement of the project.",
   },

--- a/components/research-data-table.tsx
+++ b/components/research-data-table.tsx
@@ -10,7 +10,7 @@ export function ResearchDataTable({ data }: ResearchDataTableProps) {
       <table className="min-w-full text-sm">
         <thead className="text-slate-400">
           <tr>
-            <th className="px-3 py-2 text-left font-normal">Metric</th>
+            <th className="px-3 py-2 text-left font-normal">Question</th>
             <th className="px-3 py-2 text-left font-normal">Value</th>
           </tr>
         </thead>


### PR DESCRIPTION
## Summary
- show marketcap instead of price on token detail stats
- round volume and liquidity to whole numbers
- omit pair address and DEX details from token info section

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68508efcbde0832c8d580f6750843b81