### PR TITLE
Add server-side token list hydration

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,6 +15,7 @@ import {
   fetchTokenMarketCaps,
   fetchTotalMarketCap,
   getTimeUntilNextDuneRefresh,
+  fetchAllTokensFromDune,
 } from "./actions/dune-actions";
 import { fetchDexscreenerTokenData } from "./actions/dexscreener-actions";
 import { formatCurrency, formatCurrency0 } from "@/lib/utils";
@@ -129,8 +130,12 @@ const MarketCapPieWrapper = async ({
 
 const TokenSearchListWrapper = async () => {
   try {
-    const TokenSearchList = (await import("@/components/token-search-list")).default;
-    return <TokenSearchList />;
+    const [module, tokens] = await Promise.all([
+      import("@/components/token-search-list"),
+      fetchAllTokensFromDune(),
+    ]);
+    const TokenSearchList = module.default;
+    return <TokenSearchList initialTokens={tokens} />;
   } catch (error) {
     console.error("Error loading TokenSearchList:", error);
     return (

--- a/components/token-search-list.tsx
+++ b/components/token-search-list.tsx
@@ -59,9 +59,9 @@ function formatCompactNumber(num: number): string {
   return num.toString();
 }
 
-export default function TokenSearchList() {
-  const [tokens, setTokens] = useState<TokenData[]>([]);
-  const [loading, setLoading] = useState(true);
+export default function TokenSearchList({ initialTokens }: { initialTokens?: TokenData[] }) {
+  const [tokens, setTokens] = useState<TokenData[]>(initialTokens || []);
+  const [loading, setLoading] = useState(!initialTokens);
   const [researchScores, setResearchScores] = useState<ResearchScoreData[]>([]);
   const [dexscreenerData, setDexscreenerData] = useState<Record<string, any>>({});
   const [walletInfo, setWalletInfo] = useState<Record<string, { walletLink: string; twitter: string }>>({});
@@ -102,6 +102,12 @@ export default function TokenSearchList() {
   }, []);
 
   useEffect(() => {
+    if (initialTokens && initialTokens.length > 0) {
+      setTokens(initialTokens);
+      setLoading(false);
+      return;
+    }
+
     async function loadTokens() {
       try {
         const res = await fetch("/api/tokens");
@@ -114,7 +120,7 @@ export default function TokenSearchList() {
       }
     }
     loadTokens();
-  }, []);
+  }, [initialTokens]);
 
   useEffect(() => {
     const loadResearch = async () => {


### PR DESCRIPTION
## Summary
- let `TokenSearchList` optionally take initial token data
- fetch tokens from Dune in `TokenSearchListWrapper` and pass the data to the client component
- maintain existing client-side fetch as a fallback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68509bc8bbcc832c9c4755ba6f3454d9