### PR TITLE
Remove cookie.fun link

### DIFF
--- a/components/token-search-list.tsx
+++ b/components/token-search-list.tsx
@@ -22,9 +22,7 @@ import {
   ChevronLeft,
   ChevronRight,
   Star,
-  ExternalLink,
   Twitter,
-  Cookie,
   Wallet,
   Activity,
   DollarSign,
@@ -42,9 +40,6 @@ import {
 import { canonicalChecklist } from "@/components/founders-edge-checklist";
 import { gradeMaps, valueToScore } from "@/lib/score";
 import Link from "next/link";
-
-const toSlug = (name: string = "") =>
-  name.toLowerCase().replace(/\s+/g, "-");
 
 interface ResearchScoreData {
   symbol: string;
@@ -575,15 +570,6 @@ export default function TokenSearchList() {
                             <Twitter className="w-4 h-4 text-slate-400 group-hover/btn:text-teal-400" />
                           </a>
                         )}
-                        <a
-                          href={`https://www.cookie.fun/tokens/${toSlug(token.name || token.symbol)}`}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="p-2 bg-white/5 hover:bg-white/10 border border-white/10 rounded-lg transition-colors group/btn"
-                          title="View on Cookie.fun"
-                        >
-                          <Cookie className="w-4 h-4 text-slate-400 group-hover/btn:text-teal-400" />
-                        </a>
                       </div>
                     </td>
                   </tr>


### PR DESCRIPTION
## Summary
- remove Cookie icon and link from token list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850a3f8b0f0832ca6aaacf8d242a63f