### PR TITLE
Add limit support for tokens API

### DIFF
--- a/app/api/tokens/route.ts
+++ b/app/api/tokens/route.ts
@@ -1,17 +1,29 @@
-import { NextResponse } from 'next/server';
-import { fetchAllTokensFromDune } from '@/app/actions/dune-actions';
+import { NextResponse } from 'next/server'
+import {
+  fetchAllTokensFromDune,
+  fetchPaginatedTokens,
+} from '@/app/actions/dune-actions'
 
-export async function GET() {
+export async function GET(request: Request) {
   try {
-    const tokens = await fetchAllTokensFromDune();
-    return NextResponse.json(tokens);
+    const { searchParams } = new URL(request.url)
+    const limitParam = searchParams.get('limit')
+    const limit = limitParam ? parseInt(limitParam, 10) : 0
+
+    if (limit > 0) {
+      const { tokens } = await fetchPaginatedTokens(1, limit)
+      return NextResponse.json(tokens)
+    }
+
+    const tokens = await fetchAllTokensFromDune()
+    return NextResponse.json(tokens)
   } catch (error) {
-    console.error('Error fetching tokens:', error);
+    console.error('Error fetching tokens:', error)
     return new NextResponse(JSON.stringify({ error: 'Failed to fetch tokens' }), {
       status: 500,
       headers: {
         'Content-Type': 'application/json',
       },
-    });
+    })
   }
 }

--- a/components/token-search-list.tsx
+++ b/components/token-search-list.tsx
@@ -106,7 +106,7 @@ export default function TokenSearchList() {
   useEffect(() => {
     async function loadTokens() {
       try {
-        const res = await fetch("/api/tokens");
+        const res = await fetch("/api/tokens?limit=50");
         const data = await res.json();
         setTokens(data || []);
       } catch (err) {


### PR DESCRIPTION
## Summary
- support `limit` query param in `/api/tokens`
- request only the top 50 tokens on the search list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858be69b020832ca10ad4c281b7ca44