### PR TITLE
Enable Vercel analytics

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type React from "react"
 import type { Metadata } from "next"
 
 import { ThemeProvider } from "@/components/theme-provider"
+import { Analytics } from "@vercel/analytics/react"
 import "./globals.css"
 
 
@@ -21,6 +22,7 @@ export default function RootLayout({
       <body className="font-sans bg-white text-black min-h-screen">
         <ThemeProvider attribute="class" defaultTheme="light" enableSystem disableTransitionOnChange>
           {children}
+          <Analytics />
         </ThemeProvider>
       </body>
     </html>

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@radix-ui/react-toggle-group": "1.1.1",
     "@radix-ui/react-tooltip": "1.1.6",
     "@vercel/kv": "^3.0.0",
+    "@vercel/analytics": "^1.2.2",
     "autoprefixer": "^10.4.20",
     "bcrypt": "^6.0.0",
     "bcryptjs": "^3.0.2",


### PR DESCRIPTION
## Summary
- add `@vercel/analytics` dependency
- render the `<Analytics />` component in the global layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685bfae5a788832ca23b519fa5220e57