### PR TITLE
Add Vercel Analytics

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type React from "react"
 import type { Metadata } from "next"
 
 import { ThemeProvider } from "@/components/theme-provider"
+import { Analytics } from "@vercel/analytics/react"
 import "./globals.css"
 
 
@@ -22,6 +23,7 @@ export default function RootLayout({
         <ThemeProvider attribute="class" defaultTheme="light" enableSystem disableTransitionOnChange>
           {children}
         </ThemeProvider>
+        <Analytics />
       </body>
     </html>
   )


### PR DESCRIPTION
## Summary
- import `Analytics` component from `@vercel/analytics/react`
- render `<Analytics />` in `app/layout.tsx` so it's included on every page

## Testing
- `npm install` *(fails: E403 Forbidden)*
- `npm run dev` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861a4796974832cac5c9bbe4d9aad71